### PR TITLE
Some improvements and a fix

### DIFF
--- a/Locales/PackageInfo.g
+++ b/Locales/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2023.01-05",
+Version := "2023.02-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/Locales/gap/Proset.autogen.gd
+++ b/Locales/gap/Proset.autogen.gd
@@ -32,7 +32,7 @@ DeclareOperation( "AddAreIsomorphicForObjectsIfIsHomSetInhabited",
 #! The arguments are a category $C$ and a function $F$.
 #! This operation adds the given function $F$
 #! to the category for the basic operation `UniqueMorphism`.
-#! $F: ( arg2, arg3 ) \mapsto \mathtt{UniqueMorphism}(arg2, arg3)$.
+#! $F: ( A, B ) \mapsto \mathtt{UniqueMorphism}(A, B)$.
 #! @Returns nothing
 #! @Arguments C, F
 DeclareOperation( "AddUniqueMorphism",

--- a/Locales/gap/ProsetDerivedMethods.gi
+++ b/Locales/gap/ProsetDerivedMethods.gi
@@ -239,7 +239,7 @@ AddDerivationToCAP( LiftAlongMonomorphism,
   function( cat, u1, u2 )
     
     ## the behavior of LiftAlongMonomorphism is unspecified on input violating the specification
-    return UniqueMorphism( cat, Source( u1 ), Source( u2 ) );
+    return UniqueMorphism( cat, Source( u2 ), Source( u1 ) );
     
 end : Description := "LiftAlongMonomorphism using the unique morphism from the source of the first argument to the source of the second",
       CategoryFilter := IsThinCategory );

--- a/Locales/gap/ProsetMethodRecord.gi
+++ b/Locales/gap/ProsetMethodRecord.gi
@@ -8,7 +8,10 @@ InstallValue( PREORDERED_SET_METHOD_NAME_RECORD,
         rec(
             UniqueMorphism := rec(
                                      filter_list := [ "category", "object", "object" ],
+                                     input_arguments_names := [ "cat", "A", "B" ],
                                      return_type := "morphism",
+                                     output_source_getter_string := "A",
+                                     output_range_getter_string := "B",
                                      dual_operation := "UniqueMorphism",
                                      dual_arguments_reversed := true,
                                      compatible_with_congruence_of_morphisms := true,

--- a/Toposes/PackageInfo.g
+++ b/Toposes/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Toposes",
 Subtitle := "Elementary toposes",
-Version := "2023.01-10",
+Version := "2023.02-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/Toposes/gap/ToposDerivedMethods.gi
+++ b/Toposes/gap/ToposDerivedMethods.gi
@@ -233,7 +233,7 @@ AddDerivationToCAP( EmbeddingOfIntersectionSubobject,
     
     return SubobjectOfClassifyingMorphism( ## ι1 ∧ ι2
                    cat,
-                   PreCompose(
+                   PreCompose( cat,
                            UniversalMorphismIntoDirectProduct( ## X = Range( ι1 ) = Range( ι2 ) → Ω × Ω
                                    cat,
                                    [ Omega, Omega ],

--- a/Toposes/gap/ToposMethodRecord.gi
+++ b/Toposes/gap/ToposMethodRecord.gi
@@ -125,7 +125,7 @@ SingletonMorphism := rec(
   filter_list := [ "category", "object" ],
   io_type := [ [ "object" ] , [ "object", "power_object" ] ],
   output_source_getter_string := "object",
-  output_range_getter_string := "PowerObject( object )",
+  output_range_getter_string := "PowerObject( cat, object )",
   return_type := "morphism" ),
 
 SingletonMorphismWithGivenPowerObject := rec(


### PR DESCRIPTION
I have just used CompilerForCAP for systematically verifying the sources of derivations. This has uncovered the bug in the derivation of `LiftAlongMonomorphism`.

There are many operations which cannot be checked this way due to missing `output_source/range_getter_string`s, so those should always be added.