### PR TITLE
Fix a type signature and add some checks

### DIFF
--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.02-12",
+Version := "2023.02-13",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),

--- a/FunctorCategories/gap/CategoryOfDecoratedQuivers.gd
+++ b/FunctorCategories/gap/CategoryOfDecoratedQuivers.gd
@@ -67,14 +67,41 @@ CapJitAddTypeSignature( "DefiningPairOfDecoratedQuiver", [ IsObjectInCategoryOfD
     
     Assert( 0, IsCategoryOfDecoratedQuivers( input_types[1].category ) );
     
-    return rec( filter := IsNTuple,
+    return rec(
+        filter := IsNTuple,
+        element_types := [
+            rec(
+                filter := IsNTuple,
                 element_types := [
-                        rec( filter := IsInt ),
-                        rec( filter := IsInt ),
-                        rec( filter := IsList,
-                             element_type := rec(
-                                     filter := IsNTuple,
-                                     element_types := [ rec( filter := IsInt ), rec( filter := IsInt ) ] ) ) ] );
+                    rec( filter := IsInt ),
+                    rec( filter := IsInt ),
+                    rec(
+                        filter := IsList,
+                        element_type := rec(
+                            filter := IsNTuple,
+                            element_types := [
+                                rec( filter := IsInt ),
+                                rec( filter := IsInt ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+            rec(
+                filter := IsNTuple,
+                element_types := [
+                    rec(
+                        filter := IsList,
+                        element_type := rec( filter := IsInt ),
+                    ),
+                    rec(
+                        filter := IsList,
+                        element_type := rec( filter := IsInt ),
+                    ),
+                ],
+            ),
+        ],
+    );
     
 end );
 

--- a/FunctorCategories/gap/CategoryOfDecoratedQuivers.gi
+++ b/FunctorCategories/gap/CategoryOfDecoratedQuivers.gi
@@ -37,12 +37,33 @@ InstallMethodWithCache( CategoryOfDecoratedQuivers,
         [ IsObjectInCategoryOfQuivers, IsList, IsList ],
         
   function ( decorating_quiver, decoration_of_vertices, decoration_of_arrows )
-    local object_constructor, object_datum,
+    local defining_triple,
+          object_constructor, object_datum,
           morphism_constructor, morphism_datum,
           Quivers, Slice,
           modeling_tower_object_constructor, modeling_tower_object_datum,
           modeling_tower_morphism_constructor, modeling_tower_morphism_datum,
           DecoratedQuivers;
+    
+    if not HasDefiningTripleOfQuiverEnrichedOverSkeletalFinSets( decorating_quiver ) then
+        
+        Error( "CategoryOfDecoratedQuivers can only be used with with a decorating quiver in CategoryOfQuiversEnrichedOverSkeletalFinSets" );
+        
+    fi;
+    
+    defining_triple := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( decorating_quiver );
+    
+    if Length( decoration_of_vertices ) <> defining_triple[1] then
+        
+        Error( "the number of decorations of vertices does not match the number of vertices of the decorating quiver" );
+        
+    fi;
+    
+    if Length( decoration_of_arrows ) <> defining_triple[2] then
+        
+        Error( "the number of decorations of arrows does not match the number of arrows of the decorating quiver" );
+        
+    fi;
     
     ##
     object_constructor := CreateDecoratedQuiver;


### PR DESCRIPTION
Regarding the checks:
From how we use object filters, the object filter should determine the data structure of objects. However, a category of quivers (created via `CategoryOfQuivers`) and a category of quivers enriched over SkeletalFinSets (created via `CategoryOfQuiversEnrichedOver`) have different data structures. I think `CategoryOfDecoratedQuivers` is only compatible with the latter, but cannot express this in its input filters because both have the same object filter.

tl;dr: `CategoryOfQuiversEnrichedOverFinSets` should have its own set of filters to distinguish it from `CategoryOfQuivers`.