### PR TITLE
Wrap range of hom structure in FP_GRADED_MODULES if Freyd has itself as range

### DIFF
--- a/IntrinsicGradedModules/PackageInfo.g
+++ b/IntrinsicGradedModules/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 PackageName := "IntrinsicGradedModules",
 Subtitle := "Finitely presented graded modules over computable graded rings allowing multiple presentations and the notion of elements",
 
-Version := "2023.05-02",
+Version := "2023.05-03",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/IntrinsicGradedModules/gap/FpGradedModulesByFreyd.gi
+++ b/IntrinsicGradedModules/gap/FpGradedModulesByFreyd.gi
@@ -135,7 +135,7 @@ BindGlobal( "FP_GRADED_MODULES",
         modeling_tower_morphism_datum := modeling_tower_morphism_datum,
         # enforce defaults
         only_primitive_operations := false,
-        wrap_range_of_hom_structure := false,
+        wrap_range_of_hom_structure := HasRangeCategoryOfHomomorphismStructure( Freyd ) and IsIdenticalObj( Freyd, RangeCategoryOfHomomorphismStructure( Freyd ) ),
     ) : FinalizeCategory := false );
     
     SetUnderlyingCategory( wrapper, P );


### PR DESCRIPTION
This is a preparation for `ReinterpretationOfCategory` where `wrap_range_of_hom_structure` does not make sense and which will reinterpret the range of the hom structure if and only if the modeling category has itself as its range of hom structure.