### PR TITLE
altered derivation of MorphismsOfExternalHom

### DIFF
--- a/Toposes/PackageInfo.g
+++ b/Toposes/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Toposes",
 Subtitle := "Elementary toposes",
-Version := "2023.05-04",
+Version := "2023.05-05",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/Toposes/gap/ToposDerivedMethods.gi
+++ b/Toposes/gap/ToposDerivedMethods.gi
@@ -697,23 +697,19 @@ end );
 
 ##
 AddDerivationToCAP( MorphismsOfExternalHom,
-                    "MorphismsOfExternalHom using MorphismsOfExternalHom in RangeCategoryOfHomomorphismStructure",
+                    "MorphismsOfExternalHom using ExactCoverWithGlobalElements in RangeCategoryOfHomomorphismStructure",
                     [ [ HomomorphismStructureOnObjects, 1 ],
-                      [ DistinguishedObjectOfHomomorphismStructure, 1 ],
                       [ InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism, 2 ],
-                      [ MorphismsOfExternalHom, 1, RangeCategoryOfHomomorphismStructure ] ],
+                      [ ExactCoverWithGlobalElements, 1, RangeCategoryOfHomomorphismStructure ] ],
                     
   function( cat, A, B )
-    local range_cat, hom_A_B, D, morphisms;
+    local range_cat, hom_A_B, morphisms;
     
     range_cat := RangeCategoryOfHomomorphismStructure( cat );
     
     hom_A_B := HomomorphismStructureOnObjects( cat, A, B );
     
-    D := DistinguishedObjectOfHomomorphismStructure( cat );
-    
-    morphisms := MorphismsOfExternalHom( range_cat,
-                         D, hom_A_B );
+    morphisms := ExactCoverWithGlobalElements( range_cat, hom_A_B );
     
     return List( morphisms,
                  phi -> InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism( cat,

--- a/Toposes/gap/ToposDerivedMethods.gi
+++ b/Toposes/gap/ToposDerivedMethods.gi
@@ -956,14 +956,14 @@ AddDerivationToCAP( HomomorphismStructureOnMorphismsWithGivenObjects,
                       [ UniversalMorphismFromCoproductWithGivenCoproduct, 1, RangeCategoryOfHomomorphismStructure ] ],
                     
   function( cat, source, alpha, gamma, range )
-    local range_cat, distinguished_object, Ls, tau;
+    local range_cat, distinguished_object, global_elements, tau;
     
     range_cat := RangeCategoryOfHomomorphismStructure( cat );
     distinguished_object := DistinguishedObjectOfHomomorphismStructure( cat );
     
-    Ls := ExactCoverWithGlobalElements( range_cat, source );
+    global_elements := ExactCoverWithGlobalElements( range_cat, source );
     
-    tau := List( Ls, mor ->
+    tau := List( global_elements, mor ->
                  InterpretMorphismAsMorphismFromDistinguishedObjectToHomomorphismStructureWithGivenObjects( cat,
                          distinguished_object,
                          PreComposeList( cat,


### PR DESCRIPTION
to depend on `ExactCoverWithGlobalElements` in `RangeCategoryOfHomomorphismStructure`
instead of `MorphismsOfExternalHom` in `RangeCategoryOfHomomorphismStructure`.