### PR TITLE
updated FiniteCocompletions

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2023.06-16",
+Version := "2023.06-17",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/examples/TerminalCategory_as_FiniteCoproductCocompletion.g
+++ b/FiniteCocompletions/examples/TerminalCategory_as_FiniteCoproductCocompletion.g
@@ -8,29 +8,33 @@ T := FiniteStrictCoproductCocompletion( InitialCategory( ) );
 Display( T );
 #! A CAP category with name FiniteStrictCoproductCocompletion( InitialCategory( ) ):
 #! 
-#! 93 primitive operations were used to derive 534 operations for this category
+#! 92 primitive operations were used to derive 547 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
-#! * IsBicartesianCoclosedCategory
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
+#! * IsClosedMonoidalLattice
+#! * IsCoclosedMonoidalLattice
+#! * IsBooleanAlgebra
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! * IsElementaryTopos
 #! and furthermore mathematically
+#! * IsDiscreteCategory
 #! * IsFinitelyPresentedCategory
 #! * IsFinitelyPresentedLinearCategory
 #! * IsLinearClosureOfACategory
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
-#! * IsSkeletalCategory
+#! * IsStableProset
 #! * IsStrictCartesianCategory
 #! * IsStrictCocartesianCategory
 #! * IsStrictMonoidalCategory
 #! * IsTerminalCategory
+#! * IsTotalOrderCategory
 i := InitialObject( T );
 #! <A zero object in FiniteStrictCoproductCocompletion( InitialCategory( ) )>
 t := TerminalObject( T );

--- a/FiniteCocompletions/examples/TerminalCategory_as_FiniteProductCompletion.g
+++ b/FiniteCocompletions/examples/TerminalCategory_as_FiniteProductCompletion.g
@@ -8,29 +8,31 @@ T := FiniteStrictProductCompletion( InitialCategory( ) );
 Display( T );
 #! A CAP category with name FiniteStrictProductCompletion( InitialCategory( ) ):
 #! 
-#! 91 primitive operations were used to derive 486 operations for this category
+#! 90 primitive operations were used to derive 499 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
-#! * IsBicartesianClosedCategory
-#! * IsBicartesianCoclosedCategory
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
+#! * IsClosedMonoidalLattice
+#! * IsCoclosedMonoidalLattice
+#! * IsBooleanAlgebra
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! and furthermore mathematically
+#! * IsDiscreteCategory
 #! * IsFinitelyPresentedCategory
 #! * IsFinitelyPresentedLinearCategory
 #! * IsLinearClosureOfACategory
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
-#! * IsSkeletalCategory
 #! * IsStrictCartesianCategory
 #! * IsStrictCocartesianCategory
 #! * IsStrictMonoidalCategory
 #! * IsTerminalCategory
+#! * IsTotalOrderCategory
 i := InitialObject( T );
 #! <An object in FiniteStrictProductCompletion( InitialCategory( ) )>
 t := TerminalObject( T );


### PR DESCRIPTION
Bisecting `CAP_project` shows that these changes work with https://github.com/homalg-project/CAP_project/pull/1352, which was merged two weeks ago. This is confusing since the [tests of CategoricalTowers](https://github.com/homalg-project/CategoricalTowers/actions) already worked two days ago.