### PR TITLE
Revert "updated FiniteCocompletions"

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2023.07-03",
+Version := "2023.07-04",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/examples/TerminalCategory_as_FiniteCoproductCocompletion.g
+++ b/FiniteCocompletions/examples/TerminalCategory_as_FiniteCoproductCocompletion.g
@@ -8,33 +8,29 @@ T := FiniteStrictCoproductCocompletion( InitialCategory( ) );
 Display( T );
 #! A CAP category with name FiniteStrictCoproductCocompletion( InitialCategory( ) ):
 #! 
-#! 92 primitive operations were used to derive 547 operations for this category
+#! 93 primitive operations were used to derive 534 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
+#! * IsBicartesianCoclosedCategory
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
-#! * IsClosedMonoidalLattice
-#! * IsCoclosedMonoidalLattice
-#! * IsBooleanAlgebra
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! * IsElementaryTopos
 #! and furthermore mathematically
-#! * IsDiscreteCategory
 #! * IsFinitelyPresentedCategory
 #! * IsFinitelyPresentedLinearCategory
 #! * IsLinearClosureOfACategory
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
-#! * IsStableProset
+#! * IsSkeletalCategory
 #! * IsStrictCartesianCategory
 #! * IsStrictCocartesianCategory
 #! * IsStrictMonoidalCategory
 #! * IsTerminalCategory
-#! * IsTotalOrderCategory
 i := InitialObject( T );
 #! <A zero object in FiniteStrictCoproductCocompletion( InitialCategory( ) )>
 t := TerminalObject( T );

--- a/FiniteCocompletions/examples/TerminalCategory_as_FiniteProductCompletion.g
+++ b/FiniteCocompletions/examples/TerminalCategory_as_FiniteProductCompletion.g
@@ -8,31 +8,29 @@ T := FiniteStrictProductCompletion( InitialCategory( ) );
 Display( T );
 #! A CAP category with name FiniteStrictProductCompletion( InitialCategory( ) ):
 #! 
-#! 90 primitive operations were used to derive 499 operations for this category
+#! 91 primitive operations were used to derive 486 operations for this category
 #! which algorithmically
 #! * IsCategoryWithDecidableColifts
 #! * IsCategoryWithDecidableLifts
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
+#! * IsBicartesianClosedCategory
+#! * IsBicartesianCoclosedCategory
 #! * IsAbelianCategoryWithEnoughInjectives
 #! * IsAbelianCategoryWithEnoughProjectives
-#! * IsClosedMonoidalLattice
-#! * IsCoclosedMonoidalLattice
-#! * IsBooleanAlgebra
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! and furthermore mathematically
-#! * IsDiscreteCategory
 #! * IsFinitelyPresentedCategory
 #! * IsFinitelyPresentedLinearCategory
 #! * IsLinearClosureOfACategory
 #! * IsLocallyOfFiniteInjectiveDimension
 #! * IsLocallyOfFiniteProjectiveDimension
+#! * IsSkeletalCategory
 #! * IsStrictCartesianCategory
 #! * IsStrictCocartesianCategory
 #! * IsStrictMonoidalCategory
 #! * IsTerminalCategory
-#! * IsTotalOrderCategory
 i := InitialObject( T );
 #! <An object in FiniteStrictProductCompletion( InitialCategory( ) )>
 t := TerminalObject( T );

--- a/FiniteCocompletions/tst/100_LoadPackage.tst
+++ b/FiniteCocompletions/tst/100_LoadPackage.tst
@@ -15,8 +15,6 @@ gap> LoadPackage( "FunctorCategories", false );
 true
 gap> LoadPackage( "LazyCategories", false );
 true
-gap> LoadPackage( "Locales", false );
-true
 gap> LoadPackage( "FiniteCocompletions", false );
 true
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_INFO );;
@@ -27,8 +25,6 @@ true
 gap> LoadPackage( "FunctorCategories" );
 true
 gap> LoadPackage( "LazyCategories" );
-true
-gap> LoadPackage( "Locales" );
 true
 gap> LoadPackage( "FiniteCocompletions" );
 true


### PR DESCRIPTION
This reverts commit feddcf3040f4cd395e7f8e15239501f93dcf9298.

Now that QPA does not require Locales anymore, we can revert the change.