### PR TITLE
Revert "relax timing comparison in AdditiveClosureOfAlgebroid_vs_QuiverRows.tst"

### DIFF
--- a/Algebroids/tst/AdditiveClosureOfAlgebroid_vs_QuiverRows.tst
+++ b/Algebroids/tst/AdditiveClosureOfAlgebroid_vs_QuiverRows.tst
@@ -43,7 +43,7 @@ gap> runtime_quiver := Runtime( ) - start;;
 #
 gap> if runtime >= runtime_quiver * 3 / 10 then Display( true ); else Display( runtime ); Display( runtime_quiver ); fi;
 true
-gap> if runtime <= runtime_quiver * 5 / 10 then Display( true ); else Display( runtime ); Display( runtime_quiver ); fi;
+gap> if runtime <= runtime_quiver * 4 / 10 then Display( true ); else Display( runtime ); Display( runtime_quiver ); fi;
 true
 
 #


### PR DESCRIPTION
This reverts commit 4c2dec7578d1b59458376a67d2ad7f0dc5eac1fc.

According to https://github.com/homalg-project/CategoricalTowers/pull/272#discussion_r1248936796, the regression was due to https://github.com/homalg-project/HigherHomologicalAlgebra/pull/158. Now that Locales is not loaded automatically in the tests of Algebroids anymore, the regression should be gone.