### PR TITLE
renamed (Co)YonedaEmbeddingOfUnderlyingCategory -> EmbeddingOfUnderlyingCategory

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2023.07-07",
+Version := "2023.07-08",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/examples/CartesianBraiding.g
+++ b/FiniteCocompletions/examples/CartesianBraiding.g
@@ -78,11 +78,13 @@ Display( Emb );
 #!   V
 #! LazyCategory(
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) ) )
-F := PreCompose( CoYonedaEmbeddingOfUnderlyingCategory( PC ), Emb );
-#! Precomposition of CoYoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( PC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of CoYoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(a,b)[]" ) )
@@ -91,12 +93,12 @@ Display( F );
 #! LazyCategory(
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) ) )
 G := ExtendFunctorToFiniteStrictProductCompletion( F );
-#! Extension to FiniteStrictProductCompletion( Source(
-#! Precomposition of CoYoneda embedding functor and
+#! Extension to FiniteStrictProductCompletion( Source( Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictProductCompletion( Source(
-#! Precomposition of CoYoneda embedding functor and
+#! Extension to FiniteStrictProductCompletion( Source( Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) )

--- a/FiniteCocompletions/examples/CartesianDiagonal.g
+++ b/FiniteCocompletions/examples/CartesianDiagonal.g
@@ -85,11 +85,13 @@ Display( Emb );
 #!   V
 #! LazyCategory(
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) ) )
-F := PreCompose( CoYonedaEmbeddingOfUnderlyingCategory( PC ), Emb );
-#! Precomposition of CoYoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( PC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of CoYoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(a)[]" ) )
@@ -98,12 +100,12 @@ Display( F );
 #! LazyCategory(
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) ) )
 G := ExtendFunctorToFiniteStrictProductCompletion( F );
-#! Extension to FiniteStrictProductCompletion( Source(
-#! Precomposition of CoYoneda embedding functor and
+#! Extension to FiniteStrictProductCompletion( Source( Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictProductCompletion( Source(
-#! Precomposition of CoYoneda embedding functor and
+#! Extension to FiniteStrictProductCompletion( Source( Precomposition of
+#! Embedding functor into a finite strict product completion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictProductCompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) )

--- a/FiniteCocompletions/examples/CocartesianAssociator.g
+++ b/FiniteCocompletions/examples/CocartesianAssociator.g
@@ -59,11 +59,13 @@ Display( Emb );
 #!   V
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b,c)[]" ) ) ) )
-F := PreCompose( YonedaEmbeddingOfUnderlyingCategory( UC ), Emb );
-#! Precomposition of Yoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( UC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of Yoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(a,b,c)[]" ) )
@@ -72,12 +74,12 @@ Display( F );
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b,c)[]" ) ) ) )
 G := ExtendFunctorToFiniteStrictCoproductCocompletion( F );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b,c)[]" ) ) )

--- a/FiniteCocompletions/examples/CocartesianBraiding.g
+++ b/FiniteCocompletions/examples/CocartesianBraiding.g
@@ -73,11 +73,13 @@ Display( Emb );
 #!   V
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) ) )
-F := PreCompose( YonedaEmbeddingOfUnderlyingCategory( UC ), Emb );
-#! Precomposition of Yoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( UC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of Yoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(a,b)[]" ) )
@@ -86,12 +88,12 @@ Display( F );
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) ) )
 G := ExtendFunctorToFiniteStrictCoproductCocompletion( F );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a,b)[]" ) ) )

--- a/FiniteCocompletions/examples/CocartesianCodiagonal.g
+++ b/FiniteCocompletions/examples/CocartesianCodiagonal.g
@@ -82,11 +82,13 @@ Display( Emb );
 #!   V
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) ) )
-F := PreCompose( YonedaEmbeddingOfUnderlyingCategory( UC ), Emb );
-#! Precomposition of Yoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( UC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of Yoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(a)[]" ) )
@@ -95,12 +97,12 @@ Display( F );
 #! LazyCategory(
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) ) )
 G := ExtendFunctorToFiniteStrictCoproductCocompletion( F );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( "Q(a)[]" ) ) )

--- a/FiniteCocompletions/examples/ReflexivePair.g
+++ b/FiniteCocompletions/examples/ReflexivePair.g
@@ -108,11 +108,13 @@ Display( Emb );
 #!   V
 #! LazyCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "Q(A,B)[f:A->B,g:A->B]" ) ) ) )
-F := PreCompose( YonedaEmbeddingOfUnderlyingCategory( UC ), Emb );
-#! Precomposition of Yoneda embedding functor and
+F := PreCompose( EmbeddingOfUnderlyingCategory( UC ), Emb );
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category
 Display( F );
-#! Precomposition of Yoneda embedding functor and
+#! Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category:
 #! 
 #! FreeCategory( RightQuiver( "Q(A,B)[f:A->B,g:A->B]" ) )
@@ -121,12 +123,12 @@ Display( F );
 #! LazyCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "Q(A,B)[f:A->B,g:A->B]" ) ) ) )
 G := ExtendFunctorToFiniteStrictCoproductCocompletion( F );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) )
 Display( G );
-#! Extension to FiniteStrictCoproductCocompletion( Source(
-#! Precomposition of Yoneda embedding functor and
+#! Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of
+#! Embedding functor into a finite strict coproduct cocompletion category and
 #! Embedding functor into lazy category ) ):
 #! 
 #! FiniteStrictCoproductCocompletion(

--- a/FiniteCocompletions/examples/notebooks/CartesianBraiding.ipynb
+++ b/FiniteCocompletions/examples/notebooks/CartesianBraiding.ipynb
@@ -26,7 +26,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CapAndHomalg v\u001b[32m1.5.1\u001b[39m\n",
+      "CapAndHomalg v\u001b[32m1.5.3\u001b[39m\n",
       "Imported OSCAR's components GAP and Singular_jll\n",
       "Type: ?CapAndHomalg for more information\n"
      ]
@@ -720,7 +720,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Precomposition of CoYoneda embedding functor and Embedding functor into lazy category"
+       "GAP: Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category"
       ]
      },
      "execution_count": 36,
@@ -729,7 +729,7 @@
     }
    ],
    "source": [
-    "F = PreCompose( CoYonedaEmbeddingOfUnderlyingCategory( PC ), Emb )"
+    "F = PreCompose( EmbeddingOfUnderlyingCategory( PC ), Emb )"
    ]
   },
   {
@@ -742,7 +742,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Precomposition of CoYoneda embedding functor and Embedding functor into lazy category:\n",
+      "Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category:\n",
       "\n",
       "FreeCategory( RightQuiver( \"Q(a,b)[]\" ) )\n",
       "  |\n",
@@ -764,7 +764,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Extension to FiniteStrictProductCompletion( Source( Precomposition of CoYoneda embedding functor and Embedding functor into lazy category ) )"
+       "GAP: Extension to FiniteStrictProductCompletion( Source( Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category ) )"
       ]
      },
      "execution_count": 38,
@@ -786,7 +786,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extension to FiniteStrictProductCompletion( Source( Precomposition of CoYoneda embedding functor and Embedding functor into lazy category ) ):\n",
+      "Extension to FiniteStrictProductCompletion( Source( Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category ) ):\n",
       "\n",
       "FiniteStrictProductCompletion( FreeCategory( RightQuiver( \"Q(a,b)[]\" ) ) )\n",
       "  |\n",

--- a/FiniteCocompletions/examples/notebooks/CartesianDiagonal.ipynb
+++ b/FiniteCocompletions/examples/notebooks/CartesianDiagonal.ipynb
@@ -26,7 +26,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CapAndHomalg v\u001b[32m1.5.1\u001b[39m\n",
+      "CapAndHomalg v\u001b[32m1.5.3\u001b[39m\n",
       "Imported OSCAR's components GAP and Singular_jll\n",
       "Type: ?CapAndHomalg for more information\n"
      ]
@@ -585,7 +585,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Precomposition of CoYoneda embedding functor and Embedding functor into lazy category"
+       "GAP: Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category"
       ]
      },
      "execution_count": 29,
@@ -594,7 +594,7 @@
     }
    ],
    "source": [
-    "F = PreCompose( CoYonedaEmbeddingOfUnderlyingCategory( PC ), Emb )"
+    "F = PreCompose( EmbeddingOfUnderlyingCategory( PC ), Emb )"
    ]
   },
   {
@@ -607,7 +607,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Precomposition of CoYoneda embedding functor and Embedding functor into lazy category:\n",
+      "Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category:\n",
       "\n",
       "FreeCategory( RightQuiver( \"Q(a)[]\" ) )\n",
       "  |\n",
@@ -629,7 +629,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Extension to FiniteStrictProductCompletion( Source( Precomposition of CoYoneda embedding functor and Embedding functor into lazy category ) )"
+       "GAP: Extension to FiniteStrictProductCompletion( Source( Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category ) )"
       ]
      },
      "execution_count": 31,
@@ -651,7 +651,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extension to FiniteStrictProductCompletion( Source( Precomposition of CoYoneda embedding functor and Embedding functor into lazy category ) ):\n",
+      "Extension to FiniteStrictProductCompletion( Source( Precomposition of Embedding functor into a finite strict product completion category and Embedding functor into lazy category ) ):\n",
       "\n",
       "FiniteStrictProductCompletion( FreeCategory( RightQuiver( \"Q(a)[]\" ) ) )\n",
       "  |\n",

--- a/FiniteCocompletions/examples/notebooks/ReflexivePair.ipynb
+++ b/FiniteCocompletions/examples/notebooks/ReflexivePair.ipynb
@@ -28,7 +28,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CapAndHomalg v\u001b[32m1.5.1\u001b[39m\n",
+      "CapAndHomalg v\u001b[32m1.5.3\u001b[39m\n",
       "Imported OSCAR's components GAP and Singular_jll\n",
       "Type: ?CapAndHomalg for more information\n"
      ]
@@ -780,7 +780,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Precomposition of Yoneda embedding functor and Embedding functor into lazy category"
+       "GAP: Precomposition of Embedding functor into a finite strict coproduct cocompletion category and Embedding functor into lazy category"
       ]
      },
      "execution_count": 39,
@@ -789,7 +789,7 @@
     }
    ],
    "source": [
-    "F = PreCompose( YonedaEmbeddingOfUnderlyingCategory( UC ), Emb )"
+    "F = PreCompose( EmbeddingOfUnderlyingCategory( UC ), Emb )"
    ]
   },
   {
@@ -802,7 +802,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Precomposition of Yoneda embedding functor and Embedding functor into lazy category:\n",
+      "Precomposition of Embedding functor into a finite strict coproduct cocompletion category and Embedding functor into lazy category:\n",
       "\n",
       "FreeCategory( RightQuiver( \"Q(A,B)[f:A->B,g:A->B]\" ) )\n",
       "  |\n",
@@ -824,7 +824,7 @@
     {
      "data": {
       "text/plain": [
-       "GAP: Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of Yoneda embedding functor and Embedding functor into lazy category ) )"
+       "GAP: Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of Embedding functor into a finite strict coproduct cocompletion category and Embedding functor into lazy category ) )"
       ]
      },
      "execution_count": 41,
@@ -846,7 +846,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of Yoneda embedding functor and Embedding functor into lazy category ) ):\n",
+      "Extension to FiniteStrictCoproductCocompletion( Source( Precomposition of Embedding functor into a finite strict coproduct cocompletion category and Embedding functor into lazy category ) ):\n",
       "\n",
       "FiniteStrictCoproductCocompletion( FreeCategory( RightQuiver( \"Q(A,B)[f:A->B,g:A->B]\" ) ) )\n",
       "  |\n",

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
@@ -144,5 +144,5 @@ end );
 #!  <A>ColimitQuivers</A> into <A>ColimitQuivers</A>.
 #! @Arguments ColimitQuivers
 #! @Returns a &CAP; functor
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsCategoryOfColimitQuivers );

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
@@ -269,14 +269,14 @@ InstallMethod( AssociatedCategoryOfColimitQuiversOfSourceCategory,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for the category of colimit quivers in a category",
         [ IsCategoryOfColimitQuivers ],
         
   function( ColimitQuivers )
     local Y;
     
-    Y := CapFunctor( "Yoneda embedding functor", UnderlyingCategory( ColimitQuivers ), ColimitQuivers );
+    Y := CapFunctor( "Embedding functor", UnderlyingCategory( ColimitQuivers ), ColimitQuivers );
     
     AddObjectFunction( Y, objC -> ObjectConstructor( ColimitQuivers, Pair( [ objC ], [ ] ) ) );
     
@@ -298,7 +298,7 @@ InstallMethod( \.,
     
     C := UnderlyingCategory( ColimitQuivers );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( ColimitQuivers );
+    Y := EmbeddingOfUnderlyingCategory( ColimitQuivers );
     
     Yc := Y( C.(name) );
     

--- a/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gd
+++ b/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gd
@@ -103,7 +103,7 @@ CapJitAddTypeSignature( "UnderlyingCategory", [ IsFiniteStrictCoproductCocomplet
     
 end );
 
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategoryData",
+DeclareAttribute( "EmbeddingOfUnderlyingCategoryData",
         IsFiniteStrictCoproductCocompletion );
 
 #! @Description
@@ -111,7 +111,7 @@ DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategoryData",
 #!  the finite coproduct cocompletion <A>UC</A> into <A>UC</A>.
 #! @Arguments UC
 #! @Returns a &CAP; functor
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsFiniteStrictCoproductCocompletion );
 
 DeclareOperation( "ExtendFunctorToFiniteStrictCoproductCocompletionData",
@@ -126,9 +126,9 @@ DeclareAttribute( "ExtendFunctorToFiniteStrictCoproductCocompletion",
         IsCapFunctor );
 
 #! @Description
-#!  Extend (i.e., lift) the (full) Yoneda embedding the category <A>C</A> into <C>PreSheaves</C>( <A>C</A> ) to
+#!  Extend (i.e., lift) the (full) embedding the category <A>C</A> into <C>PreSheaves</C>( <A>C</A> ) to
 #!  the full embedding of <C>FiniteStrictCoproductCocompletion</C>( <A>C</A> ) into <C>PreSheaves</C>( <A>C</A> ).
 #! @Arguments C
 #! @Returns a &CAP; functor
-DeclareAttribute( "ExtendYonedaEmbeddingToFiniteStrictCoproductCocompletion",
+DeclareAttribute( "ExtendEmbeddingToFiniteStrictCoproductCocompletion",
         IsCapCategory );

--- a/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gi
+++ b/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gi
@@ -1115,36 +1115,36 @@ InstallMethod( FiniteStrictCoproductCocompletion,
 end );
 
 ##
-InstallMethodForCompilerForCAP( YonedaEmbeddingOfUnderlyingCategoryData,
+InstallMethodForCompilerForCAP( EmbeddingOfUnderlyingCategoryData,
         "for a finite coproduct cocompletion category",
         [ IsFiniteStrictCoproductCocompletion ],
         
   function( UC )
-    local yoneda_embedding_on_objects, yoneda_embedding_on_morphisms;
+    local embedding_on_objects, embedding_on_morphisms;
     
-    yoneda_embedding_on_objects :=
+    embedding_on_objects :=
       objC -> ObjectConstructor( UC, Pair( 1, [ objC ] ) );
     
-    yoneda_embedding_on_morphisms :=
+    embedding_on_morphisms :=
       { source, morC, range } -> MorphismConstructor( UC, source, Pair( [ 0 ], [ morC ] ), range );
     
     return Triple( UnderlyingCategory( UC ),
-                   Pair( yoneda_embedding_on_objects, yoneda_embedding_on_morphisms ),
+                   Pair( embedding_on_objects, embedding_on_morphisms ),
                    UC );
     
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a finite coproduct cocompletion category",
         [ IsFiniteStrictCoproductCocompletion ],
         
   function( UC )
     local data, Y;
     
-    data := YonedaEmbeddingOfUnderlyingCategoryData( UC );
+    data := EmbeddingOfUnderlyingCategoryData( UC );
     
-    Y := CapFunctor( "Yoneda embedding functor", data[1], UC );
+    Y := CapFunctor( "Embedding functor into a finite strict coproduct cocompletion category", data[1], UC );
     
     AddObjectFunction( Y, data[2][1] );
     
@@ -1166,7 +1166,7 @@ InstallMethod( \.,
     
     C := UnderlyingCategory( UC );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( UC );
+    Y := EmbeddingOfUnderlyingCategory( UC );
     
     Yc := Y( C.(name) );
     
@@ -1312,13 +1312,13 @@ InstallMethod( ExtendFunctorToFiniteStrictCoproductCocompletion,
 end );
 
 ##
-InstallMethod( ExtendYonedaEmbeddingToFiniteStrictCoproductCocompletion,
+InstallMethod( ExtendEmbeddingToFiniteStrictCoproductCocompletion,
         "for a CAP category",
         [ IsCapCategory ],
         
   function( C )
     
-    return ExtendFunctorToFiniteStrictCoproductCocompletion( YonedaEmbedding( C ) );
+    return ExtendFunctorToFiniteStrictCoproductCocompletion( Embedding( C ) );
     
 end );
 

--- a/FiniteCocompletions/gap/FiniteStrictProductCompletion.gd
+++ b/FiniteCocompletions/gap/FiniteStrictProductCompletion.gd
@@ -102,7 +102,7 @@ CapJitAddTypeSignature( "UnderlyingCategory", [ IsFiniteStrictProductCompletion 
 
 end );
 
-DeclareAttribute( "CoYonedaEmbeddingOfUnderlyingCategoryData",
+DeclareAttribute( "EmbeddingOfUnderlyingCategoryData",
         IsFiniteStrictProductCompletion );
 
 #! @Description
@@ -110,7 +110,7 @@ DeclareAttribute( "CoYonedaEmbeddingOfUnderlyingCategoryData",
 #!  the finite product completion <A>PC</A> into <A>PC</A>.
 #! @Arguments PC
 #! @Returns a &CAP; functor
-DeclareAttribute( "CoYonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsFiniteStrictProductCompletion );
 
 DeclareOperation( "ExtendFunctorToFiniteStrictProductCompletionData",

--- a/FiniteCocompletions/gap/FiniteStrictProductCompletion.gi
+++ b/FiniteCocompletions/gap/FiniteStrictProductCompletion.gi
@@ -208,36 +208,36 @@ InstallMethod( FiniteStrictProductCompletion,
 end );
 
 ##
-InstallMethodForCompilerForCAP( CoYonedaEmbeddingOfUnderlyingCategoryData,
+InstallMethodForCompilerForCAP( EmbeddingOfUnderlyingCategoryData,
         "for a finite coproduct cocompletion category",
         [ IsFiniteStrictProductCompletion ],
         
   function( PC )
-    local yoneda_embedding_on_objects, yoneda_embedding_on_morphisms;
+    local embedding_on_objects, embedding_on_morphisms;
     
-    yoneda_embedding_on_objects :=
+    embedding_on_objects :=
       objC -> ObjectConstructor( PC, Pair( 1, [ objC ] ) );
     
-    yoneda_embedding_on_morphisms :=
+    embedding_on_morphisms :=
       { source, morC, range } -> MorphismConstructor( PC, source, Pair( [ 0 ], [ morC ] ), range );
     
     return Triple( UnderlyingCategory( PC ),
-                   Pair( yoneda_embedding_on_objects, yoneda_embedding_on_morphisms ),
+                   Pair( embedding_on_objects, embedding_on_morphisms ),
                    PC );
     
 end );
 
 ##
-InstallMethod( CoYonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a finite coproduct cocompletion category",
         [ IsFiniteStrictProductCompletion ],
         
   function( PC )
     local data, Y;
     
-    data := CoYonedaEmbeddingOfUnderlyingCategoryData( PC );
+    data := EmbeddingOfUnderlyingCategoryData( PC );
     
-    Y := CapFunctor( "CoYoneda embedding functor", data[1], PC );
+    Y := CapFunctor( "Embedding functor into a finite strict product completion category", data[1], PC );
     
     AddObjectFunction( Y, data[2][1] );
     
@@ -259,7 +259,7 @@ InstallMethod( \.,
     
     C := UnderlyingCategory( PC );
     
-    Y := CoYonedaEmbeddingOfUnderlyingCategory( PC );
+    Y := EmbeddingOfUnderlyingCategory( PC );
     
     Yc := Y( C.(name) );
     

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.07-11",
+Version := "2023.07-12",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/gap/AbelianClosure.gd
+++ b/FunctorCategories/gap/AbelianClosure.gd
@@ -50,7 +50,7 @@ DeclareAttribute( "UnderlyingCategory",
 
 #! @Arguments abelian_closure
 #! @Returns a &CAP; functor
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsAbelianClosure );
 
 ####################################

--- a/FunctorCategories/gap/AbelianClosure.gi
+++ b/FunctorCategories/gap/AbelianClosure.gi
@@ -43,7 +43,7 @@ InstallMethod( AbelianClosure,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for an Abelian closure category",
         [ IsAbelianClosure ],
         
@@ -52,7 +52,7 @@ InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
     
     Freyd := ModelingCategory( abelian_closure );
     
-    Y := CoYonedaEmbeddingOfUnderlyingCategory( UnderlyingCategory( Freyd ) );
+    Y := EmbeddingOfUnderlyingCategory( UnderlyingCategory( Freyd ) );
     
     return PreCompose(
                    PreCompose( Y, EmbeddingFunctorIntoFreydCategory( UnderlyingCategory( Freyd ) ) ),
@@ -72,7 +72,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( abelian_closure );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( abelian_closure );
+    Y := EmbeddingOfUnderlyingCategory( abelian_closure );
     
     Yc := Y( F.(name) );
     

--- a/FunctorCategories/gap/CategoryOfBouquets.gd
+++ b/FunctorCategories/gap/CategoryOfBouquets.gd
@@ -63,7 +63,7 @@ DeclareAttribute( "UnderlyingCategory",
         IsCategoryOfBouquets );
 
 #! @Arguments fin_bouquets
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsCategoryOfBouquets );
 
 DeclareAttribute( "DefiningTripleOfBouquetEnrichedOverSkeletalFinSets",

--- a/FunctorCategories/gap/CategoryOfBouquets.gi
+++ b/FunctorCategories/gap/CategoryOfBouquets.gi
@@ -309,7 +309,7 @@ InstallMethod( Subobject,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a category of bouquets",
         [ IsCategoryOfBouquets ],
         
@@ -342,7 +342,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( category_of_bouquets );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( category_of_bouquets );
+    Y := EmbeddingOfUnderlyingCategory( category_of_bouquets );
     
     Yc := Y( F.(name) );
     

--- a/FunctorCategories/gap/CategoryOfDecoratedQuivers.gd
+++ b/FunctorCategories/gap/CategoryOfDecoratedQuivers.gd
@@ -57,7 +57,7 @@ DeclareAttribute( "DecorationOfArrows",
         IsCategoryOfDecoratedQuivers );
 
 #! @Arguments decorated_fin_quivers
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsCategoryOfDecoratedQuivers );
 
 DeclareAttribute( "DefiningPairOfDecoratedQuiver",

--- a/FunctorCategories/gap/CategoryOfDecoratedQuivers.gi
+++ b/FunctorCategories/gap/CategoryOfDecoratedQuivers.gi
@@ -305,7 +305,7 @@ InstallMethod( Subobject,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a category of decorated quivers",
         [ IsCategoryOfDecoratedQuivers ],
         
@@ -338,7 +338,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( category_of_quivers );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( category_of_quivers );
+    Y := EmbeddingOfUnderlyingCategory( category_of_quivers );
     
     Yc := Y( F.(name) );
     

--- a/FunctorCategories/gap/CategoryOfQuivers.gd
+++ b/FunctorCategories/gap/CategoryOfQuivers.gd
@@ -60,7 +60,7 @@ DeclareAttribute( "UnderlyingCategory",
         IsCategoryOfQuivers );
 
 #! @Arguments fin_quivers
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsCategoryOfQuivers );
 
 DeclareAttribute( "DefiningTripleOfQuiverEnrichedOverSkeletalFinSets",

--- a/FunctorCategories/gap/CategoryOfQuivers.gi
+++ b/FunctorCategories/gap/CategoryOfQuivers.gi
@@ -318,7 +318,7 @@ InstallMethod( Subobject,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a category of quivers",
         [ IsCategoryOfQuivers ],
         
@@ -351,7 +351,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( category_of_quivers );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( category_of_quivers );
+    Y := EmbeddingOfUnderlyingCategory( category_of_quivers );
     
     Yc := Y( F.(name) );
     

--- a/FunctorCategories/gap/CategoryOfReflexiveQuivers.gd
+++ b/FunctorCategories/gap/CategoryOfReflexiveQuivers.gd
@@ -63,7 +63,7 @@ DeclareAttribute( "UnderlyingCategory",
         IsCategoryOfReflexiveQuivers );
 
 #! @Arguments fin_reflexive_quivers
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsCategoryOfReflexiveQuivers );
 
 DeclareAttribute( "DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets",

--- a/FunctorCategories/gap/CategoryOfReflexiveQuivers.gi
+++ b/FunctorCategories/gap/CategoryOfReflexiveQuivers.gi
@@ -342,7 +342,7 @@ InstallMethod( Subobject,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a category of finite reflexive quivers",
         [ IsCategoryOfReflexiveQuivers ],
         
@@ -375,7 +375,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( category_of_quivers );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( category_of_quivers );
+    Y := EmbeddingOfUnderlyingCategory( category_of_quivers );
     
     if name = "V" then
         name := "C0";

--- a/FunctorCategories/gap/FiniteCocompletion.gd
+++ b/FunctorCategories/gap/FiniteCocompletion.gd
@@ -50,7 +50,7 @@ DeclareAttribute( "UnderlyingCategory",
 
 #! @Arguments finite_cocompletion
 #! @Returns a &CAP; functor
-DeclareAttribute( "YonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsFiniteCocompletion );
 
 ####################################

--- a/FunctorCategories/gap/FiniteCocompletion.gi
+++ b/FunctorCategories/gap/FiniteCocompletion.gi
@@ -43,7 +43,7 @@ InstallMethod( FiniteCocompletion,
 end );
 
 ##
-InstallMethod( YonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a finite cocompletion category",
         [ IsFiniteCocompletion ],
         
@@ -68,7 +68,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( finite_cocompletion );
     
-    Y := YonedaEmbeddingOfUnderlyingCategory( finite_cocompletion );
+    Y := EmbeddingOfUnderlyingCategory( finite_cocompletion );
     
     Yc := Y( F.(name) );
     

--- a/FunctorCategories/gap/FiniteCompletion.gd
+++ b/FunctorCategories/gap/FiniteCompletion.gd
@@ -50,7 +50,7 @@ DeclareAttribute( "UnderlyingCategory",
 
 #! @Arguments finite_completion
 #! @Returns a &CAP; functor
-DeclareAttribute( "CoYonedaEmbeddingOfUnderlyingCategory",
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
         IsFiniteCompletion );
 
 ####################################

--- a/FunctorCategories/gap/FiniteCompletion.gi
+++ b/FunctorCategories/gap/FiniteCompletion.gi
@@ -57,7 +57,7 @@ InstallMethod( FiniteCompletion,
 end );
 
 ##
-InstallMethod( CoYonedaEmbeddingOfUnderlyingCategory,
+InstallMethod( EmbeddingOfUnderlyingCategory,
         "for a finite completion category",
         [ IsFiniteCompletion ],
         
@@ -82,7 +82,7 @@ InstallMethod( \.,
     
     F := UnderlyingCategory( finite_completion );
     
-    Y := CoYonedaEmbeddingOfUnderlyingCategory( finite_completion );
+    Y := EmbeddingOfUnderlyingCategory( finite_completion );
     
     Yc := Y( F.(name) );
     


### PR DESCRIPTION
reasons:
* when composing such free constructions there is no natural way to choose between Yoneda and CoYoneda
* these embeddings are the obvious embeddings while the (Co)Yoneda embedding is a lemma

-> stop the inflationary use of the prefix Yoneda and restrict it to the original context