### PR TITLE
refactored CoYonedaLemmaOnObjects/Morphisms to be enrichment-agnostic

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2023.08-09",
+Version := "2023.08-10",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2023.08-08",
+Version := "2023.08-09",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
+++ b/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
@@ -1,0 +1,104 @@
+#! @BeginChunk CategoryOfColimitQuivers
+
+#! @Example
+LoadPackage( "FunctorCategories" );
+#! true
+FinBouquets;
+#! FinBouquets
+Chat := ModelingCategory( FinBouquets );
+#! FiniteCocompletion( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
+Ccqv := CategoryOfColimitQuivers(
+                 UnderlyingCategory( FinBouquets ) );
+#! CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
+P := Ccqv.P;
+#! <A projective object in CategoryOfColimitQuivers(
+#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
+Display( P );
+#! [ [ <(P)> ], [  ] ]
+#! 
+#! An object in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+L := Ccqv.L;
+#! <A projective object in CategoryOfColimitQuivers(
+#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
+Display( L );
+#! [ [ <(L)> ], [  ] ]
+#! 
+#! An object in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+b := Ccqv.b;
+#! <A morphism in CategoryOfColimitQuivers(
+#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
+Display( b );
+#! Source: [ [ <(P)> ], [  ] ]
+#! 
+#! An object in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! Datum:  [ [ [ 0 ], [ (P)-[(b)]->(L) ] ], [  ] ]
+#! 
+#! Range:  [ [ <(L)> ], [  ] ]
+#! 
+#! An object in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! A morphism in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+F := CreateBouquet( 3, [ 0, 0, 0, 2 ] );
+#! <An object in FinBouquets>
+Display( F );
+#! ( { 0, 1, 2 }, { 0 ↦ 0, 1 ↦ 0, 2 ↦ 0, 3 ↦ 2 } )
+F_as_presheaf := ModelingObject( Chat, ModelingObject( FinBouquets, F ) );
+#! <An object in PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ),
+#!  SkeletalFinSets )>
+F_as_coequalizer_pair := CoYonedaLemmaOnObjects( F_as_presheaf );
+#! <An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) )>
+Display( F_as_coequalizer_pair );
+#! Image of <(V)>:
+#! [ 7, [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)>, <(L)> ] ]
+#! 
+#! An object in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! Image of <(A)>:
+#! [ 4, [ <(P)>, <(P)>, <(P)>, <(P)> ] ]
+#! 
+#! An object in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! Image of (V)-[(s)]->(A):
+#! { 0,..., 3 } ⱶ[ 0, 0, 0, 2 ]→ { 0,..., 6 }
+#! 
+#! [ (P)-[(P)]->(P), (P)-[(P)]->(P), (P)-[(P)]->(P), (P)-[(P)]->(P) ]
+#! 
+#! A morphism in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! Image of (V)-[(t)]->(A):
+#! { 0,..., 3 } ⱶ[ 3, 4, 5, 6 ]→ { 0,..., 6 }
+#! 
+#! [ (P)-[(b)]->(L), (P)-[(b)]->(L), (P)-[(b)]->(L), (P)-[(b)]->(L) ]
+#! 
+#! A morphism in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! 
+#! An object in PreSheaves( FreeCategory( RightQuiver( "q(V,A)[s:V->A,t:V->A]" ) ),
+#! FiniteStrictCoproductCocompletion(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
+#! 
+#! An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
+F_as_colimit_quiver := ReinterpretationOfObject( Ccqv, F_as_coequalizer_pair );
+#! <An object in CategoryOfColimitQuivers(
+#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
+Display( F_as_colimit_quiver );
+#! [ [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)>, <(L)> ],
+#!   [ [ 0, (P)-[(b)]->(L), 3 ], [ 0, (P)-[(b)]->(L), 4 ],
+#!     [ 0, (P)-[(b)]->(L), 5 ], [ 2, (P)-[(b)]->(L), 6 ] ] ]
+#! 
+#! An object in CategoryOfColimitQuivers(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+#! @EndExample
+#! @EndChunk

--- a/FiniteCocompletions/examples/FinBouquetsAsFiniteColimitCocompletion.g
+++ b/FiniteCocompletions/examples/FinBouquetsAsFiniteColimitCocompletion.g
@@ -1,75 +1,25 @@
 #! @BeginChunk FinBouquetsAsFiniteColimitCocompletion
 
 #! @Example
-LoadPackage( "FunctorCategories" );
+LoadPackage( "FunctorCategories", ">= 2023.08-20" );
 #! true
 FinBouquets;
 #! FinBouquets
-Cbar := ModelingCategory( FinBouquets );
+Chat := ModelingCategory( FinBouquets );
 #! FiniteCocompletion( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
-Cbar2 := CategoryOfColimitQuivers(
-                 UnderlyingCategory( FinBouquets ) );
-#! CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
-P := Cbar2.P;
-#! <A projective object in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( P );
-#! [ [ <(P)> ], [  ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-L := Cbar2.L;
-#! <A projective object in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( L );
-#! [ [ <(L)> ], [  ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-b := Cbar2.b;
-#! <A morphism in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( b );
-#! Source: [ [ <(P)> ], [  ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-#! 
-#! Datum:  [ [ [ 0 ], [ (P)-[(b)]->(L) ] ], [  ] ]
-#! 
-#! Range:  [ [ <(L)> ], [  ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-#! 
-#! A morphism in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
 source_bouquet := CreateBouquet( 3, [ 0, 0, 1 ] );
 #! <An object in FinBouquets>
 Display( source_bouquet );
 #! ( { 0, 1, 2 }, { 0 ↦ 0, 1 ↦ 0, 2 ↦ 1 } )
-source_presheaf := ModelingObject( Cbar,
+source_presheaf := ModelingObject( Chat,
                            ModelingObject( FinBouquets, source_bouquet ) );
 #! <An object in
 #!  PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ), SkeletalFinSets )>
-source_colimit_quiver := CoYonedaLemmaOnObjects( source_presheaf );
-#! <An object in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( source_colimit_quiver );
-#! [ [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)> ],
-#!   [ [ 0, (P)-[(b)]->(L), 3 ], [ 0, (P)-[(b)]->(L), 4 ],
-#!     [ 1, (P)-[(b)]->(L), 5 ] ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-IsWellDefined( source_colimit_quiver );
-#! true
-source_coeq_pair :=
-  ModelingObject( CapCategory( source_colimit_quiver ), source_colimit_quiver );
-#! <An object in PairOfParallelArrowsCategory(
-#!  FiniteStrictCoproductCocompletion(
+source_coeq_pair := CoYonedaLemmaOnObjects( source_presheaf );
+#! <An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) )>
+IsWellDefined( source_coeq_pair );
+#! true
 Display( source_coeq_pair );
 #! Image of <(V)>:
 #! [ 6, [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)> ] ]
@@ -103,38 +53,18 @@ Display( source_coeq_pair );
 #! FiniteStrictCoproductCocompletion(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
 #! 
-#! An object in PairOfParallelArrowsCategory(
-#! FiniteStrictCoproductCocompletion( FreeCategory(
-#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
-ReinterpretationOfObject( CapCategory( source_colimit_quiver ),
-        source_coeq_pair ) = source_colimit_quiver;
-#! true
+#! An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
 target_bouquet := CreateBouquet( 2, [ 0, 0, 0, 0, 1 ] );
 #! <An object in FinBouquets>
 Display( target_bouquet );
 #! ( { 0, 1 }, { 0 ↦ 0, 1 ↦ 0, 2 ↦ 0, 3 ↦ 0, 4 ↦ 1 } )
-target_presheaf := ModelingObject( Cbar,
+target_presheaf := ModelingObject( Chat,
                            ModelingObject( FinBouquets, target_bouquet ) );
 #! <An object in
 #!  PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ), SkeletalFinSets )>
-target_colimit_quiver := CoYonedaLemmaOnObjects( target_presheaf );
-#! <An object in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( target_colimit_quiver );
-#! [ [ <(P)>, <(P)>, <(L)>, <(L)>, <(L)>, <(L)>, <(L)> ],
-#!   [ [ 0, (P)-[(b)]->(L), 2 ], [ 0, (P)-[(b)]->(L), 3 ],
-#!     [ 0, (P)-[(b)]->(L), 4 ], [ 0, (P)-[(b)]->(L), 5 ],
-#!     [ 1, (P)-[(b)]->(L), 6 ] ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
-#! given by the above data
-IsWellDefined( target_colimit_quiver );
-#! true
-target_coeq_pair :=
-  ModelingObject( CapCategory( target_colimit_quiver ), target_colimit_quiver );
-#! <An object in PairOfParallelArrowsCategory(
-#!  FiniteStrictCoproductCocompletion(
+target_coeq_pair := CoYonedaLemmaOnObjects( target_presheaf );
+#! <An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) )>
 Display( target_coeq_pair );
 #! Image of <(V)>:
@@ -169,12 +99,8 @@ Display( target_coeq_pair );
 #! FiniteStrictCoproductCocompletion(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
 #! 
-#! An object in PairOfParallelArrowsCategory(
-#! FiniteStrictCoproductCocompletion( FreeCategory(
-#! RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
-ReinterpretationOfObject( CapCategory( target_colimit_quiver ),
-        target_coeq_pair ) = target_colimit_quiver;
-#! true
+#! An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
+#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
 bouquet_morphism := CreateBouquetMorphism(
                             source_bouquet,
                             [ 0, 1, 1 ], [ 1, 3, 4 ],
@@ -182,43 +108,15 @@ bouquet_morphism := CreateBouquetMorphism(
 #! <A morphism in FinBouquets>
 IsWellDefined( bouquet_morphism );
 #! true
-presheaf_morphism := ModelingMorphism( Cbar,
+presheaf_morphism := ModelingMorphism( Chat,
                              ModelingMorphism( FinBouquets, bouquet_morphism ) );
 #! <A morphism in
 #!  PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ), SkeletalFinSets )>
-colimit_quiver_morphism := CoYonedaLemmaOnMorphisms( presheaf_morphism );
-#! <A morphism in CategoryOfColimitQuivers(
-#!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-Display( colimit_quiver_morphism );
-#! Source: [ [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)> ],
-#!         [ [ 0, (P)-[(b)]->(L), 3 ], [ 0, (P)-[(b)]->(L), 4 ],
-#!           [ 1, (P)-[(b)]->(L), 5 ] ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-#! 
-#! Datum:  [ [ [ 0, 1, 1, 3, 5, 6 ],
-#!             [ (P)-[(P)]->(P), (P)-[(P)]->(P), (P)-[(P)]->(P),
-#!               (L)-[(L)]->(L), (L)-[(L)]->(L), (L)-[(L)]->(L) ] ],
-#!           [ 1, 3, 4 ] ]
-#! 
-#! Range:  [ [ <(P)>, <(P)>, <(L)>, <(L)>, <(L)>, <(L)>, <(L)> ],
-#!           [ [ 0, (P)-[(b)]->(L), 2 ], [ 0, (P)-[(b)]->(L), 3 ],
-#!             [ 0, (P)-[(b)]->(L), 4 ], [ 0, (P)-[(b)]->(L), 5 ],
-#!             [ 1, (P)-[(b)]->(L), 6 ] ] ]
-#! 
-#! An object in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-#! 
-#! A morphism in CategoryOfColimitQuivers(
-#! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-IsWellDefined( colimit_quiver_morphism );
-#! true
-coeq_pair_morphism :=
-  ModelingMorphism( CapCategory( colimit_quiver_morphism ), colimit_quiver_morphism );
-#! <A morphism in PairOfParallelArrowsCategory(
-#!  FiniteStrictCoproductCocompletion(
+coeq_pair_morphism := CoYonedaLemmaOnMorphisms( presheaf_morphism );
+#! <A morphism in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) )>
+IsWellDefined( coeq_pair_morphism );
+#! true
 Display( coeq_pair_morphism );
 #! Image of <(V)>:
 #! { 0,..., 5 } ⱶ[ 0, 1, 1, 3, 5, 6 ]→ { 0,..., 6 }
@@ -241,13 +139,7 @@ Display( coeq_pair_morphism );
 #! FiniteStrictCoproductCocompletion(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
 #! 
-#! A morphism in PairOfParallelArrowsCategory(
-#! FiniteStrictCoproductCocompletion(
+#! A morphism in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) ) given by the above data
-ReinterpretationOfMorphism( CapCategory( colimit_quiver_morphism ),
-        source_colimit_quiver,
-        coeq_pair_morphism,
-        target_colimit_quiver ) = colimit_quiver_morphism;
-#! true
 #! @EndExample
 #! @EndChunk

--- a/FiniteCocompletions/examples/FinReflexiveQuiversAsFiniteColimitCocompletion.g
+++ b/FiniteCocompletions/examples/FinReflexiveQuiversAsFiniteColimitCocompletion.g
@@ -1,7 +1,7 @@
 #! @BeginChunk FinReflexiveQuiversAsFiniteColimitCocompletion
 
 #! @Example
-LoadPackage( "FunctorCategories" );
+LoadPackage( "FunctorCategories", ">= 2023.08-20" );
 #! true
 Delta1 := SimplicialCategoryTruncatedInDegree( 1 );
 #! FreeCategory( RightQuiver(
@@ -31,28 +31,61 @@ Display( PSh.C1 );
 #! An object in PreSheaves( FreeCategory( RightQuiver(
 #! "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
 #! SkeletalFinSets ) given by the above data
-quiver := CoYonedaLemmaOnObjects( PSh.C1 );
-#! <An object in CategoryOfColimitQuivers(
+coeq_pair := CoYonedaLemmaOnObjects( PSh.C1 );
+#! <An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #!  FreeCategory( RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
-#!  / [ s*id = C0, t*id = C0 ] )>
-Display( quiver );
-#! [ [ <(C0)>, <(C0)>, <(C1)>, <(C1)>, <(C1)> ],
-#!   [ [ 3, (C1)-[(id)]->(C0), 0 ], [ 4, (C1)-[(id)]->(C0), 1 ],
-#!     [ 0, (C0)-[(s)]->(C1), 2 ], [ 0, (C0)-[(s)]->(C1), 3 ],
-#!     [ 1, (C0)-[(s)]->(C1), 4 ], [ 1, (C0)-[(t)]->(C1), 2 ],
-#!     [ 0, (C0)-[(t)]->(C1), 3 ], [ 1, (C0)-[(t)]->(C1), 4 ] ] ]
-#! An object in CategoryOfColimitQuivers(
+#!  / [ s*id = C0, t*id = C0 ] ) )>
+Display( coeq_pair );
+#! Image of <(V)>:
+#! [ 5, [ <(C0)>, <(C0)>, <(C1)>, <(C1)>, <(C1)> ] ]
+#! 
+#! An object in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
+#! / [ s*id = C0, t*id = C0 ] ) given by the above data
+#! 
+#! Image of <(A)>:
+#! [ 8, [ <(C1)>, <(C1)>, <(C0)>, <(C0)>, <(C0)>, <(C0)>, <(C0)>, <(C0)> ] ]
+#! 
+#! An object in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
+#! / [ s*id = C0, t*id = C0 ] ) given by the above data
+#! 
+#! Image of (V)-[(s)]->(A):
+#! { 0,..., 7 } ⱶ[ 3, 4, 0, 0, 1, 1, 0, 1 ]→ { 0,..., 4 }
+#! 
+#! [ (C1)-[(C1)]->(C1), (C1)-[(C1)]->(C1), (C0)-[(C0)]->(C0), (C0)-[(C0)]->(C0),
+#!   (C0)-[(C0)]->(C0), (C0)-[(C0)]->(C0), (C0)-[(C0)]->(C0), (C0)-[(C0)]->(C0) ]
+#! 
+#! A morphism in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
+#! / [ s*id = C0, t*id = C0 ] ) given by the above data
+#! 
+#! Image of (V)-[(t)]->(A):
+#! { 0,..., 7 } ⱶ[ 0, 1, 2, 3, 4, 2, 3, 4 ]→ { 0,..., 4 }
+#! 
+#! [ (C1)-[(id)]->(C0), (C1)-[(id)]->(C0), (C0)-[(s)]->(C1), (C0)-[(s)]->(C1),
+#!   (C0)-[(s)]->(C1), (C0)-[(t)]->(C1), (C0)-[(t)]->(C1), (C0)-[(t)]->(C1) ]
+#! 
+#! A morphism in FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
+#! / [ s*id = C0, t*id = C0 ] ) given by the above data
+#! 
+#! An object in PreSheaves( FreeCategory( RightQuiver( "q(V,A)[s:V->A,t:V->A]" ) ),
+#! FiniteStrictCoproductCocompletion( FreeCategory(
+#! RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
+#! / [ s*id = C0, t*id = C0 ] ) ) given by the above data
+#! 
+#! An object in PairOfParallelArrowsCategory( FiniteStrictCoproductCocompletion(
 #! FreeCategory( RightQuiver( "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) )
-#! / [ s*id = C0, t*id = C0 ] )
-#! given by the above data
-IsWellDefined( quiver );
+#! / [ s*id = C0, t*id = C0 ] ) ) given by the above data
+IsWellDefined( coeq_pair );
 #! true
-q := SomeDiagramOfRepresentables( PSh.C1 );;
-colimit := Colimit( q );
+coeq_pair_in_presheaves := CoYonedaLemmaCoequalizerPair( PSh.C1 );;
+coeq := Coequalizer( coeq_pair_in_presheaves[2] );
 #! <An object in PreSheaves( FreeCategory( RightQuiver(
 #!  "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
-#! SkeletalFinSets )>
-Display( colimit );
+#!  SkeletalFinSets )>
+Display( coeq );
 #! Image of <(C0)>:
 #! { 0, 1 }
 #! 
@@ -71,13 +104,7 @@ Display( colimit );
 #! An object in PreSheaves( FreeCategory( RightQuiver(
 #! "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
 #! SkeletalFinSets ) given by the above data
-colimit2 := Coequalizer( ColimitPair( PSh, q[1], q[2] )[2] );
-#! <An object in PreSheaves( FreeCategory( RightQuiver(
-#!  "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
-#! SkeletalFinSets )>
-colimit2 = colimit;
-#! true
-iso := Filtered( MorphismsOfExternalHom( PSh.C1, colimit ), IsIsomorphism )[1];
+iso := Filtered( MorphismsOfExternalHom( PSh.C1, coeq ), IsIsomorphism )[1];
 #! <An isomorphism in PreSheaves( FreeCategory( RightQuiver(
 #!  "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
 #!  SkeletalFinSets )>

--- a/FiniteCocompletions/examples/Jordan.g
+++ b/FiniteCocompletions/examples/Jordan.g
@@ -1,0 +1,129 @@
+#! @BeginChunk Jordan
+
+#! @Example
+LoadPackage( "FunctorCategories" );
+#! true
+q := RightQuiver( "q(o)[x:o->o]" );
+#! q(o)[x:o->o]
+F := FreeCategory( q );
+#! FreeCategory( RightQuiver( "q(o)[x:o->o]" ) )
+Q := HomalgFieldOfRationals( );
+#! Q
+QF := Q[F];
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) )
+A := QF / [ QF.xxx ];
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations
+o := A.o;
+#! <(o)>
+x := A.x;
+#! (o)-[{ 1*(x) }]->(o)
+Qmat := RangeCategoryOfHomomorphismStructure( A );
+#! Rows( Q )
+U := 3 / Qmat;
+#! <A row module over Q of rank 3>
+phi := HomalgMatrix( [ 0,1,0, 0,0,1, 0,0,0 ], 3, 3, Q ) / Qmat;
+#! <A morphism in Rows( Q )>
+Display( phi );
+#! Source:
+#! A row module over Q of rank 3
+#! 
+#! Matrix:
+#! [ [  0,  1,  0 ],
+#!   [  0,  0,  1 ],
+#!   [  0,  0,  0 ] ]
+#! 
+#! Range:
+#! A row module over Q of rank 3
+#! 
+#! A morphism in Rows( Q )
+PSh := PreSheaves( A );
+#! PreSheaves( Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) )
+#! / relations, Rows( Q ) )
+Mphi := CreatePreSheafByValues( PSh, Pair( [ U ], [ phi ] ) );
+#! <(o)->3; (x)->3x3>
+Display( Mphi );
+#! Image of <(o)>:
+#! A row module over Q of rank 3
+#! 
+#! Image of (o)-[{ 1*(x) }]->(o):
+#! Source:
+#! A row module over Q of rank 3
+#! 
+#! Matrix:
+#! [ [  0,  1,  0 ],
+#!   [  0,  0,  1 ],
+#!   [  0,  0,  0 ] ]
+#! 
+#! Range:
+#! A row module over Q of rank 3
+#! 
+#! A morphism in Rows( Q )
+#! 
+#! An object in PreSheaves(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations,
+#! Rows( Q ) ) given by the above data
+Mphi_as_coequqlizer_pair := CoYonedaLemmaOnObjects( Mphi );
+#! <An object in PairOfParallelArrowsCategory( Additive closure(
+#!  Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations ) )>
+Display( Mphi_as_coequqlizer_pair );
+#! Image of <(V)>:
+#! A formal direct sum consisting of 3 objects.
+#! <(o)>
+#! <(o)>
+#! <(o)>
+#! 
+#! Image of <(A)>:
+#! A formal direct sum consisting of 3 objects.
+#! <(o)>
+#! <(o)>
+#! <(o)>
+#! 
+#! Image of (V)-[(s)]->(A):
+#! A 3 x 3 matrix with entries in
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations
+#! 
+#! [1,1]: (o)-[{ 0 }]->(o)
+#! [1,2]: (o)-[{ 1*(o) }]->(o)
+#! [1,3]: (o)-[{ 0 }]->(o)
+#! [2,1]: (o)-[{ 0 }]->(o)
+#! [2,2]: (o)-[{ 0 }]->(o)
+#! [2,3]: (o)-[{ 1*(o) }]->(o)
+#! [3,1]: (o)-[{ 0 }]->(o)
+#! [3,2]: (o)-[{ 0 }]->(o)
+#! [3,3]: (o)-[{ 0 }]->(o)
+#! Image of (V)-[(t)]->(A):
+#! A 3 x 3 matrix with entries in
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations
+#! 
+#! [1,1]: (o)-[{ 1*(x) }]->(o)
+#! [1,2]: (o)-[{ 0 }]->(o)
+#! [1,3]: (o)-[{ 0 }]->(o)
+#! [2,1]: (o)-[{ 0 }]->(o)
+#! [2,2]: (o)-[{ 1*(x) }]->(o)
+#! [2,3]: (o)-[{ 0 }]->(o)
+#! [3,1]: (o)-[{ 0 }]->(o)
+#! [3,2]: (o)-[{ 0 }]->(o)
+#! [3,3]: (o)-[{ 1*(x) }]->(o)
+#! An object in PreSheaves( FreeCategory( RightQuiver( "q(V,A)[s:V->A,t:V->A]" ) ),
+#! Additive closure( Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) /
+#! relations ) ) given by the above data
+#! 
+#! An object in PairOfParallelArrowsCategory( Additive closure(
+#! Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations ) )
+#! given by the above data
+phi_in_additive_closure :=
+  TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure( o, phi );
+#! <A morphism in Additive closure(
+#!  Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations )
+#!  defined by a 3 x 3 matrix of underlying morphisms>
+x_in_additive_closure :=
+  TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure( x, U );
+#! <A morphism in Additive closure(
+#!  Algebra( Q, FreeCategory( RightQuiver( "q(o)[x:o->o]" ) ) ) / relations )
+#!  defined by a 3 x 3 matrix of underlying morphisms>
+Mphi_as_coequqlizer_pair.s = phi_in_additive_closure;
+#! true
+Mphi_as_coequqlizer_pair.t = x_in_additive_closure;
+#! true
+#! @EndExample
+#! @EndChunk

--- a/FiniteCocompletions/gap/AdditiveClosure.gi
+++ b/FiniteCocompletions/gap/AdditiveClosure.gi
@@ -148,3 +148,97 @@ InstallMethod( ExtendFunctorToStrictAdditiveClosure,
     return UF;
     
 end );
+
+##
+InstallOtherMethodForCompilerForCAP( TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for a category of rows, an additive closure category, an object in the additive category, and an object in the category of rows",
+        [ IsCategoryOfRows,
+          IsAdditiveClosureCategory and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsCategoryOfRowsObject ],
+        
+  function( H, UL, a, h )
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( a ), UnderlyingCategory( UL ) ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( h ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UL ), H ) );
+    
+    return ObjectConstructor( UL, ListWithIdenticalEntries( ObjectDatum( H, h ), a ) );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure,
+        "for a category of rows, an additive closure category, three objects in the additive category, and a morphism in the category of rows",
+        [ IsCategoryOfRows,
+          IsAdditiveClosureCategory and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsCapCategoryObject, IsCategoryOfRowsMorphism, IsCapCategoryObject ],
+        
+  function( H, UL, source, a, nu, range )
+    local L, id_a, s, t, nu_matrix;
+    
+    L := UnderlyingCategory( UL );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( a ), L ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( nu ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UL ), H ) );
+    
+    id_a := IdentityMorphism( L, a );
+    
+    s := ObjectDatum( H, Source( nu ) );
+    t := ObjectDatum( H, Range( nu ) );
+    
+    nu_matrix := MorphismDatum( H, nu );
+    
+    return MorphismConstructor( UL,
+                   source,
+                   List( [ 1 .. s ], i ->
+                         List( [ 1 .. t ], j ->
+                               MultiplyWithElementOfCommutativeRingForMorphisms( L, nu_matrix[i, j], id_a ) ) ),
+                   range );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for a category of rows, an additive closure category, two objects and a morphism in the additive category, and an object in the category of rows",
+        [ IsCategoryOfRows,
+          IsAdditiveClosureCategory and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsCapCategoryMorphism, IsCategoryOfRowsObject, IsCapCategoryObject ],
+        
+  function( H, UL, source, phi, h, range )
+    local l, Uphi;
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( phi ), UnderlyingCategory( UL ) ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( h ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UL ), H ) );
+    
+    l := ObjectDatum( H, h );
+    
+    Uphi := MorphismConstructor( UL,
+                   ObjectConstructor( UL, [ Source( phi ) ] ),
+                   [ [ phi ] ],
+                   ObjectConstructor( UL, [ Range( phi ) ] ) );
+    
+    return DirectSumFunctorialWithGivenDirectSums( UL,
+                   source,
+                   ListWithIdenticalEntries( l, Source( Uphi ) ),
+                   ListWithIdenticalEntries( l, Uphi ),
+                   ListWithIdenticalEntries( l, Range( Uphi ) ),
+                   range );
+    
+end );

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
@@ -92,8 +92,7 @@ end );
 #! @Arguments C
 DeclareAttribute( "CategoryOfColimitQuivers",
         IsCapCategory );
-#! @InsertChunk FinBouquetsAsFiniteColimitCocompletion
-#! @InsertChunk FinReflexiveQuiversAsFiniteColimitCocompletion
+#! @InsertChunk CategoryOfColimitQuivers
 
 CapJitAddTypeSignature( "CategoryOfColimitQuivers", [ IsCapCategory ], function ( input_types )
     

--- a/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gi
+++ b/FiniteCocompletions/gap/FiniteStrictCoproductCocompletion.gi
@@ -1326,6 +1326,93 @@ InstallMethod( ExtendEmbeddingToFiniteStrictCoproductCocompletion,
     
 end );
 
+##
+InstallOtherMethodForCompilerForCAP( TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for a skeletal category of finite sets, a finite strict coproduct cocompletion, an object in the cocartesian category, and an object in the skeletal category of finite sets",
+        [ IsCategoryOfSkeletalFinSets,
+          IsFiniteStrictCoproductCocompletion and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsSkeletalFiniteSet ],
+        
+  function( H, UC, c, h )
+    local l;
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( c ), UnderlyingCategory( UC ) ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( h ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UC ), H ) );
+    
+    l := ObjectDatum( H, h );
+    
+    return ObjectConstructor( UC, Pair( l, ListWithIdenticalEntries( l, c ) ) );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure,
+        "for a skeletal category of finite sets, a finite strict coproduct cocompletion, three objects in the cocartesian category, and a morphism in the skeletal category of finite sets",
+        [ IsCategoryOfSkeletalFinSets,
+          IsFiniteStrictCoproductCocompletion and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsCapCategoryObject, IsSkeletalFiniteSetMap, IsCapCategoryObject ],
+        
+  function( H, UC, source, c, nu, range )
+    local C, id_d, s, nu_list;
+    
+    C := UnderlyingCategory( UC );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( c ), C ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( nu ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UC ), H ) );
+    
+    id_d := IdentityMorphism( C, c );
+    
+    s := ObjectDatum( H, Source( nu ) );
+    
+    nu_list := MorphismDatum( H, nu );
+    
+    return MorphismConstructor( UC,
+                   source,
+                   Pair( nu_list, ListWithIdenticalEntries( s, id_d ) ),
+                   range );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for a skeletal category of finite sets, a finite strict coproduct cocompletion, two objects and a morphism in the cocartesian category, and an object in the skeletal category of finite sets",
+        [ IsCategoryOfSkeletalFinSets,
+          IsFiniteStrictCoproductCocompletion and HasRangeCategoryOfHomomorphismStructure,
+          IsCapCategoryObject, IsCapCategoryMorphism, IsSkeletalFiniteSet, IsCapCategoryObject ],
+        
+  function( H, UC, source, phi, h, range )
+    local l;
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( phi ), UnderlyingCategory( UC ) ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( h ), H ) );
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( UC ), H ) );
+    
+    l := ObjectDatum( H, h );
+    
+    return MorphismConstructor( UC,
+                   source,
+                   Pair( [ 0 .. l - 1 ], ListWithIdenticalEntries( l, phi ) ),
+                   range );
+    
+end );
+
 ##################################
 ##
 ## View & Display

--- a/FiniteCocompletions/gap/PairOfParallelArrowsCategory.gd
+++ b/FiniteCocompletions/gap/PairOfParallelArrowsCategory.gd
@@ -115,3 +115,5 @@ end );
 #! @Arguments cat
 DeclareAttribute( "PairOfParallelArrowsCategory",
         IsCapCategory );
+#! @InsertChunk FinBouquetsAsFiniteColimitCocompletion
+#! @InsertChunk FinReflexiveQuiversAsFiniteColimitCocompletion

--- a/FiniteCocompletions/gap/Tools.gd
+++ b/FiniteCocompletions/gap/Tools.gd
@@ -53,3 +53,4 @@ DeclareOperation( "TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStruc
 #! @Returns a &CAP; morphism
 DeclareOperation( "TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure",
         [ IsCapCategoryMorphism, IsCapCategoryObject ] );
+#! @InsertChunk Jordan

--- a/FiniteCocompletions/gap/Tools.gd
+++ b/FiniteCocompletions/gap/Tools.gd
@@ -14,3 +14,42 @@
 
 DeclareOperation( "EnrichmentSpecificFiniteStrictCoproductCocompletion",
         [ IsCapCategory, IsCapCategory ] );
+
+#! @Description
+#!  The arguments are an ojbect <A>objC</A> in a category $C$ and
+#!  an object <A>objH</A> in $H :=$ <C>RangeCategoryOfHomomorphismStructure</C>( $C$ ).
+#!  The output is an object in <C>EnrichmentSpecificFiniteStrictCoproductCocompletion</C>( $C$ ),
+#!  namely the tensor product <A>objC</A> $\otimes$ <A>objH</A>, i.e.,
+#!  the formal coproduct of $l$ copies of <A>objC</A>, where $l :=$ <C>ObjectDatum</C>( <A>objH</A> )
+#!  is a nonnegative integer.
+#! @Arguments objC, objH
+#! @Returns a &CAP; object
+DeclareOperation( "TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure",
+        [ IsCapCategoryObject, IsCapCategoryObject ] );
+
+#! @Description
+#!  The arguments are an ojbect <A>objC</A> in a cocartesian category $C$ and
+#!  a morphism <A>morH</A> in $H :=$ <C>RangeCategoryOfHomomorphismStructure</C>( $C$ ).
+#!  The output is a morphism in <C>EnrichmentSpecificFiniteStrictCoproductCocompletion</C>( $C$ ),
+#!  namely the tensor product <A>objC</A> $\otimes$ <A>morH</A>, i.e.,
+#!  the morphism induced by <A>morH</A> from the formal coproduct of $t$ copies of <A>objC</A>
+#!  to the formal coproduct of $t$ copies of <A>objC</A>, where
+#!  $s :=$ <C>ObjectDatum</C>( <C>Source</C>( <A>morH</A> ) ) and
+#!  $t :=$ <C>ObjectDatum</C>( <C>Range</C>( <A>morH</A> ) ).
+#! @Arguments objC, morH
+#! @Returns a &CAP; morphism
+DeclareOperation( "TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure",
+        [ IsCapCategoryObject, IsCapCategoryMorphism ] );
+
+#! @Description
+#!  The arguments are a morphism <A>morC</A> in a cocartesian category $C$ and
+#!  an object <A>objH</A> in $H :=$ <C>RangeCategoryOfHomomorphismStructure</C>( $C$ ).
+#!  The output is a morphism in <C>EnrichmentSpecificFiniteStrictCoproductCocompletion</C>( $C$ ),
+#!  namely the tensor product <A>morC</A> $\otimes$ <A>objH</A>, i.e.,
+#!  the morphism induced by <A>morC</A> of the formal coproduct of $l$ copies of <C>Source</C>( <A>morC</A> )
+#!  to the formal coproduct of $l$ copies of <C>Range</C>( <A>morC</A> ), where
+#!  $l :=$ <C>ObjectDatum</C>( <A>objH</A> ).
+#! @Arguments morC, objH
+#! @Returns a &CAP; morphism
+DeclareOperation( "TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure",
+        [ IsCapCategoryMorphism, IsCapCategoryObject ] );

--- a/FiniteCocompletions/gap/Tools.gi
+++ b/FiniteCocompletions/gap/Tools.gi
@@ -18,3 +18,55 @@ InstallMethod( EnrichmentSpecificFiniteStrictCoproductCocompletion,
     return EnrichmentSpecificFiniteStrictCoproductCocompletion( C, RangeCategoryOfHomomorphismStructure( C ) );
     
 end );
+
+##
+InstallMethod( TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for an object in a cocartesian category and an object in the its range category of the homomorphism structure",
+        [ IsCapCategoryObject, IsCapCategoryObject ],
+        
+  function( c, h )
+    local UC;
+    
+    UC := EnrichmentSpecificFiniteStrictCoproductCocompletion( CapCategory( c ) );
+    
+    return TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure( RangeCategoryOfHomomorphismStructure( UC ), UC, c, h );
+    
+end );
+
+##
+InstallMethod( TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure,
+        "an object in a cocartesian category and a morphism in its range category of the homomorphism structure",
+        [ IsCapCategoryObject, IsCapCategoryMorphism ],
+        
+  function( c, nu )
+    local UC, H;
+    
+    UC := EnrichmentSpecificFiniteStrictCoproductCocompletion( CapCategory( c ) );
+    H := RangeCategoryOfHomomorphismStructure( UC );
+    
+    return TensorizeObjectWithMorphismInRangeCategoryOfHomomorphismStructure( H, UC,
+                   TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure( H, UC, c, Source( nu ) ),
+                   c,
+                   nu,
+                   TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure( H, UC, c, Range( nu ) ) );
+    
+end );
+
+##
+InstallMethod( TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure,
+        "for a morphism in a cocartesian category and an object in its range category of the homomorphism structure",
+        [ IsCapCategoryMorphism, IsCapCategoryObject ],
+        
+  function( phi, h )
+    local UC, H;
+    
+    UC := EnrichmentSpecificFiniteStrictCoproductCocompletion( CapCategory( phi ) );
+    H := RangeCategoryOfHomomorphismStructure( UC );
+    
+    return TensorizeMorphismWithObjectInRangeCategoryOfHomomorphismStructure( H, UC,
+                   TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure( H, UC, Source( phi ), h ),
+                   phi,
+                   h,
+                   TensorizeObjectWithObjectInRangeCategoryOfHomomorphismStructure( H, UC, Range( phi ), h ) );
+    
+end );

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.08-18",
+Version := "2023.08-19",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.08-19",
+Version := "2023.08-20",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
@@ -93,12 +93,12 @@ Dependencies := rec(
                    [ "MonoidalCategories", ">= 2023.02-04" ],
                    [ "CartesianCategories", ">= 2023.02-04" ],
                    [ "Algebroids", ">= 2023.08-01" ],
-                   [ "FiniteCocompletions", ">= 2023.08-07" ],
+                   [ "FiniteCocompletions", ">= 2023.08-09" ],
                    [ "PreSheaves", ">= 2023.03-03" ],
                    [ "RingsForHomalg", ">= 2020.02.04" ],
                    [ "LinearAlgebraForCAP", ">= 2020.01.10" ],
                    [ "FreydCategoriesForCAP", ">= 2019.11.02" ],
-                   [ "CategoryConstructor", ">= 2023.08-01" ],
+                   [ "CategoryConstructor", ">= 2023.08-02" ],
                    [ "SubcategoriesForCAP", ">= 2023.07-01" ],
                    [ "Toposes", ">= 2023.08-03" ],
                    [ "FinSetsForCAP", ">= 2023.05-06" ],

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.08-17",
+Version := "2023.08-18",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/gap/CategoryOfReflexiveQuivers.gd
+++ b/FunctorCategories/gap/CategoryOfReflexiveQuivers.gd
@@ -49,7 +49,7 @@ if false then
 DeclareGlobalVariable( "QuiverOfCategoryOfReflexiveQuivers" );
 
 #! The category of reflexive quivers as a category of presheaves with values in <C>SkeletalFinSets</C>.
-DeclareGlobalVariable( "FinQuivers" );
+DeclareGlobalVariable( "FinReflexiveQuivers" );
 fi;
 
 ####################################

--- a/FunctorCategories/gap/CompilerLogic.gi
+++ b/FunctorCategories/gap/CompilerLogic.gi
@@ -70,6 +70,22 @@ end );
 
 CapJitAddLogicTemplate(
     rec(
+        variable_names := [ "number" ],
+        src_template := "number + 1 - 1",
+        dst_template := "number",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "number" ],
+        src_template := "1 + number - 1",
+        dst_template := "number",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
         variable_names := [ ],
         src_template := "[ 0 .. BigInt( -1 ) ]",
         dst_template := "[ ]",
@@ -86,9 +102,9 @@ CapJitAddLogicTemplate(
 
 CapJitAddLogicTemplate(
     rec(
-        variable_names := [ ],
-        src_template := "[ 2 .. 2 ]",
-        dst_template := "[ 2 ]",
+        variable_names := [ "number" ],
+        src_template := "[ number .. number ]",
+        dst_template := "[ number ]",
     )
 );
 
@@ -254,6 +270,14 @@ CapJitAddLogicTemplate(
 
 CapJitAddLogicTemplate(
     rec(
+        variable_names := [ "number" ],
+        src_template := "Length( [ 0 .. number - 1 ] )",
+        dst_template := "number",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
         variable_names := [ "number1", "number2" ],
         src_template := "Sum( ListWithIdenticalEntries( number1, number2 ) )",
         dst_template := "number1 * number2",
@@ -386,6 +410,14 @@ CapJitAddLogicTemplate(
 
 CapJitAddLogicTemplate(
     rec(
+        variable_names := [ "number", "entry" ],
+        src_template := "Concatenation( ListWithIdenticalEntries( number, [ entry ] ) )",
+        dst_template := "ListWithIdenticalEntries( number, entry )",
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
         variable_names := [ "matrix", "dimension", "ring" ],
         src_template := "matrix * HomalgIdentityMatrix( dimension, ring )",
         dst_template := "matrix",
@@ -447,5 +479,21 @@ CapJitAddLogicTemplate(
         variable_names := [  ],
         src_template := "SafeUniquePosition( [ 0, 1 ], 1 )",
         dst_template := "2"
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "length", "index" ],
+        src_template := "SafeUniquePosition( [ 0 .. length - 1 ], index )",
+        dst_template := "1 + index"
+    )
+);
+
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "length", "number", "index" ],
+        src_template := "Sum( ListWithIdenticalEntries( length, number ){[ 1 .. index ]} )",
+        dst_template := "number * index"
     )
 );

--- a/FunctorCategories/gap/HomStructure.gi
+++ b/FunctorCategories/gap/HomStructure.gi
@@ -49,26 +49,21 @@ InstallMethodForCompilerForCAP( ExternalHomOnMorphismsEqualizerFunctorialDataUsi
         [ IsPreSheafCategoryOfFpEnrichedCategory, IsMorphismInPreSheafCategoryOfFpEnrichedCategory, IsMorphismInPreSheafCategoryOfFpEnrichedCategory ],
         
   function ( PSh, eta, rho )
-    local Bhat, CoequalizerPairs, UC, F, G, eta_colimit_quiver_morphism,
+    local CoequalizerPairs, UC, F, G,
           eta_coequalizer_pair_morphism, eta_coequalizer_pair_as_presheaf_morphism, eta_coequalizer_pair_as_presheaf_morphism_datum,
           S, eta_V_S, F_data, F_V, F_V_data, diagram_F_V_S, T, diagram_F_V_T, D, F_V_rho;
     
-    Bhat := AssociatedCategoryOfColimitQuiversOfSourceCategory( PSh );
-    
-    CoequalizerPairs := ModelingCategory( Bhat );
+    CoequalizerPairs := AssociatedCategoryOfCoequalizerPairsOfSourceCategory( PSh );
     
     UC := UnderlyingCategory( CoequalizerPairs );
     
     F := Source( eta );
     G := Range( eta );
     
-    eta_colimit_quiver_morphism := CoYonedaLemmaOnMorphisms( PSh,
-                                           CoYonedaLemmaOnObjects( PSh, F ),
-                                           eta,
-                                           CoYonedaLemmaOnObjects( PSh, G ) );
-    
-    eta_coequalizer_pair_morphism :=
-      ModelingMorphism( Bhat, eta_colimit_quiver_morphism );
+    eta_coequalizer_pair_morphism := CoYonedaLemmaOnMorphisms( PSh,
+                                             CoYonedaLemmaOnObjects( PSh, F ),
+                                             eta,
+                                             CoYonedaLemmaOnObjects( PSh, G ) );
     
     eta_coequalizer_pair_as_presheaf_morphism :=
       ModelingMorphism( CoequalizerPairs, eta_coequalizer_pair_morphism );

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -319,6 +319,10 @@ DeclareAttribute( "SomeDiagramOfRepresentables",
 DeclareAttribute( "CoequalizerDataOfPreSheafUsingCoYonedaLemma",
         IsObjectInPreSheafCategory );
 
+#! @Arguments PSh
+DeclareAttribute( "EmbeddingFunctorOfFiniteStrictCoproductCocompletionIntoPreSheavesData",
+        IsPreSheafCategory );
+
 #! @Arguments PSh, objB, morC, F
 DeclareOperation( "MorphismFromRepresentable",
     [ IsPreSheafCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsObjectInPreSheafCategory ] );

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -167,7 +167,8 @@ end );
 
 #! @Description
 #!  Given the presheaf category <A>PSh</A>=<C>PSh</C>($C,V$) return
-#!  the equivalent category <C>CategoryOfColimitQuivers</C>( $C$ ).
+#!  the ambient category <C>CategoryOfColimitQuivers</C>( $C$ ), provided
+#!  $C$ is enriched over <C>SkeletalFinSets</C>.
 #! @Arguments PSh
 #! @Returns a &CAP; category
 DeclareAttribute( "AssociatedCategoryOfColimitQuiversOfSourceCategory",
@@ -312,11 +313,11 @@ DeclareOperation( "CreatePreSheafMorphismByFunction",
         [ IsObjectInPreSheafCategory, IsFunction, IsObjectInPreSheafCategory ] );
 
 #! @Arguments F
-DeclareAttribute( "SomeDiagramOfRepresentables",
+DeclareAttribute( "CoequalizerDataOfPreSheafUsingCoYonedaLemma",
         IsObjectInPreSheafCategory );
 
 #! @Arguments F
-DeclareAttribute( "CoequalizerDataOfPreSheafUsingCoYonedaLemma",
+DeclareAttribute( "CoYonedaLemmaCoequalizerPair",
         IsObjectInPreSheafCategory );
 
 #! @Arguments PSh

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -2901,6 +2901,18 @@ InstallMethod( CoequalizerDataOfPreSheafUsingCoYonedaLemma,
 end );
 
 ##
+InstallMethodForCompilerForCAP( EmbeddingFunctorOfFiniteStrictCoproductCocompletionIntoPreSheavesData,
+        [ IsPreSheafCategoryOfFpEnrichedCategory ],
+        
+  function ( PSh )
+    local UC;
+    
+    UC := AssociatedFiniteStrictCoproductCocompletionOfSourceCategory( PSh );
+    
+    return ExtendFunctorToFiniteStrictCoproductCocompletionData( UC, YonedaEmbeddingData( PSh ), PSh );
+    
+end );
+
 ## a special case of InterpretMorphismFromDistinguishedObjectToHomomorphismStructureAsMorphism
 InstallMethodForCompilerForCAP( MorphismFromRepresentable,
         [ IsPreSheafCategory, IsCapCategoryObject, IsCapCategoryMorphism, IsObjectInPreSheafCategory ],

--- a/FunctorCategories/gap/precompiled_categories/FinBouquetsAsCCCPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinBouquetsAsCCCPrecompiled.gi
@@ -10,125 +10,95 @@ BindGlobal( "ADD_FUNCTIONS_FOR_FinBouquetsAsCCCPrecompiled", function ( cat )
         
 ########
 function ( cat_1, a_1, b_1 )
-    local hoisted_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, hoisted_13_1, hoisted_14_1, deduped_15_1, hoisted_19_1, hoisted_23_1, deduped_24_1, hoisted_26_1, hoisted_28_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1;
-    deduped_45_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( b_1 );
-    deduped_44_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( a_1 );
-    deduped_43_1 := deduped_45_1[3];
-    deduped_42_1 := deduped_45_1[2];
-    deduped_41_1 := deduped_44_1[2];
-    deduped_40_1 := deduped_45_1[1];
-    deduped_39_1 := deduped_44_1[1];
-    deduped_38_1 := ListWithIdenticalEntries( deduped_39_1, deduped_40_1 );
-    deduped_37_1 := [ 0 .. deduped_39_1 - 1 ];
-    deduped_36_1 := [ 0 .. deduped_41_1 - 1 ];
-    deduped_35_1 := Concatenation( deduped_38_1, ListWithIdenticalEntries( deduped_41_1, deduped_42_1 ) );
-    deduped_34_1 := [ 0 .. Product( deduped_38_1 ) - 1 ];
-    deduped_33_1 := [ 0 .. Product( deduped_35_1 ) - 1 ];
-    deduped_32_1 := Filtered( deduped_34_1, function ( x_2 )
+    local hoisted_2_1, hoisted_5_1, hoisted_6_1, deduped_7_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, hoisted_15_1, deduped_16_1, hoisted_18_1, hoisted_20_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1;
+    deduped_35_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( b_1 );
+    deduped_34_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( a_1 );
+    deduped_33_1 := deduped_34_1[2];
+    deduped_32_1 := deduped_35_1[1];
+    deduped_31_1 := deduped_34_1[1];
+    deduped_30_1 := ListWithIdenticalEntries( deduped_31_1, deduped_32_1 );
+    deduped_29_1 := [ 0 .. deduped_31_1 - 1 ];
+    deduped_28_1 := [ 0 .. deduped_33_1 - 1 ];
+    deduped_27_1 := Concatenation( deduped_30_1, ListWithIdenticalEntries( deduped_33_1, deduped_35_1[2] ) );
+    deduped_26_1 := [ 0 .. Product( deduped_30_1 ) - 1 ];
+    deduped_25_1 := [ 0 .. Product( deduped_27_1 ) - 1 ];
+    deduped_24_1 := Filtered( deduped_26_1, function ( x_2 )
             return true;
         end );
-    hoisted_19_1 := List( deduped_36_1, function ( i_2 )
+    hoisted_10_1 := deduped_35_1[3];
+    hoisted_9_1 := [ deduped_31_1 .. deduped_31_1 + deduped_33_1 - 1 ];
+    hoisted_11_1 := List( deduped_28_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) + deduped_39_1);
-            hoisted_2_2 := deduped_35_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_35_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_33_1, function ( i_3 )
-                    return deduped_43_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+            deduped_3_2 := hoisted_9_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_27_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_27_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_25_1, function ( i_3 )
+                    return hoisted_10_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
                 end );
         end );
-    deduped_10_1 := [ deduped_40_1, deduped_42_1 ];
-    deduped_9_1 := [ 0, 1 ];
-    deduped_4_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, 0 ), ListWithIdenticalEntries( deduped_41_1, 1 ) );
-    hoisted_2_1 := deduped_44_1[3];
-    deduped_3_1 := List( deduped_36_1, function ( i_2 )
-            return hoisted_2_1[1 + REM_INT( i_2, deduped_41_1 )];
+    hoisted_6_1 := ListWithIdenticalEntries( deduped_33_1, deduped_32_1 );
+    deduped_7_1 := List( deduped_28_1, function ( j_2 )
+            return Product( hoisted_6_1{[ 1 .. j_2 ]} );
         end );
-    hoisted_14_1 := List( deduped_36_1, function ( i_2 )
-            return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_3_1[(1 + i_2)]] )];
-        end );
-    deduped_15_1 := List( deduped_36_1, function ( j_2 )
-            return Product( hoisted_14_1{[ 1 .. j_2 ]} );
-        end );
-    deduped_8_1 := [ 0, 1, 2 ];
-    deduped_7_1 := [ 0, 1, 1 ];
-    deduped_6_1 := [ 0, 0, 1 ];
-    deduped_5_1 := [ 0, 2 ];
-    hoisted_13_1 := List( deduped_36_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
-            deduped_7_2 := 1 + deduped_3_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ))];
-            deduped_6_2 := 1 + deduped_5_1[(1 + deduped_4_1[deduped_7_2])];
-            deduped_5_2 := deduped_6_1[deduped_6_2];
-            deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-            hoisted_3_2 := CAP_JIT_INCOMPLETE_LOGIC( IdFunc( function (  )
-                        if IdFunc( function (  )
-                                    if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_7_1[deduped_6_2] = deduped_7_1[deduped_4_2] then
-                                        return deduped_8_1[deduped_6_2] = deduped_8_1[deduped_4_2];
-                                    else
-                                        return false;
-                                    fi;
-                                    return;
-                                end )(  ) then
-                            return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-                        else
-                            return deduped_43_1;
-                        fi;
-                        return;
-                    end )(  ) );
-            hoisted_2_2 := deduped_35_1[deduped_7_2];
-            hoisted_1_2 := Product( deduped_35_1{[ 1 .. deduped_7_2 - 1 ]} );
-            return List( deduped_33_1, function ( i_3 )
-                    return hoisted_3_2[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
-                end );
-        end );
-    deduped_31_1 := Filtered( deduped_33_1, function ( x_2 )
-            local deduped_1_2;
-            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_36_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_13_1[deduped_1_3][deduped_1_2] * deduped_15_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_36_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_19_1[deduped_1_3][deduped_1_2] * deduped_15_1[deduped_1_3];
-                    end ) );
-        end );
-    deduped_30_1 := Length( deduped_31_1 );
-    deduped_24_1 := List( deduped_37_1, function ( j_2 )
-            return Product( deduped_38_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_23_1 := List( [ 1 .. deduped_39_1 ], function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := Product( deduped_38_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_34_1, function ( i_3 )
-                    return REM_INT( QUO_INT( i_3, hoisted_1_2 ), deduped_40_1 );
-                end );
-        end );
-    hoisted_28_1 := List( deduped_34_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_37_1, function ( j_3 )
-                    local deduped_1_3;
-                    deduped_1_3 := 1 + j_3;
-                    return hoisted_23_1[deduped_1_3][hoisted_1_2] * deduped_24_1[deduped_1_3];
-                end );
-        end );
-    hoisted_26_1 := List( [ 0 .. Length( deduped_37_1 ) - 1 ], function ( i_2 )
+    hoisted_2_1 := deduped_34_1[3];
+    hoisted_5_1 := List( deduped_28_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-            hoisted_2_2 := deduped_35_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_35_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_33_1, function ( i_3 )
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_33_1 )] );
+            hoisted_2_2 := deduped_27_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_27_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_25_1, function ( i_3 )
                     return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfBouquetEnrichedOverSkeletalFinSets, NTuple( 3, Length( deduped_32_1 ), deduped_30_1, List( [ 0 .. deduped_30_1 - 1 ], function ( x_2 )
+    deduped_23_1 := Filtered( deduped_25_1, function ( x_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_28_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_5_1[deduped_1_3][deduped_1_2] * deduped_7_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_28_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_11_1[deduped_1_3][deduped_1_2] * deduped_7_1[deduped_1_3];
+                    end ) );
+        end );
+    deduped_22_1 := Length( deduped_23_1 );
+    deduped_16_1 := List( deduped_29_1, function ( j_2 )
+            return Product( deduped_30_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_15_1 := List( [ 1 .. deduped_31_1 ], function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := Product( deduped_30_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_26_1, function ( i_3 )
+                    return REM_INT( QUO_INT( i_3, hoisted_1_2 ), deduped_32_1 );
+                end );
+        end );
+    hoisted_20_1 := List( deduped_26_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := 1 + i_2;
+            return Sum( deduped_29_1, function ( j_3 )
+                    local deduped_1_3;
+                    deduped_1_3 := 1 + j_3;
+                    return hoisted_15_1[deduped_1_3][hoisted_1_2] * deduped_16_1[deduped_1_3];
+                end );
+        end );
+    hoisted_18_1 := List( deduped_29_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
+            hoisted_2_2 := deduped_27_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_27_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_25_1, function ( i_3 )
+                    return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
+                end );
+        end );
+    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfBouquetEnrichedOverSkeletalFinSets, NTuple( 3, Length( deduped_24_1 ), deduped_22_1, List( [ 0 .. deduped_22_1 - 1 ], function ( x_2 )
                 local hoisted_1_2;
-                hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_31_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
-                return -1 + BigInt( SafePosition( deduped_32_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_28_1[(1 + Sum( deduped_37_1, function ( j_3 )
+                hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_23_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
+                return -1 + BigInt( SafePosition( deduped_24_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_20_1[(1 + Sum( deduped_29_1, function ( j_3 )
                                    local deduped_1_3;
                                    deduped_1_3 := (1 + j_3);
-                                   return hoisted_26_1[deduped_1_3][hoisted_1_2] * deduped_24_1[deduped_1_3];
+                                   return hoisted_18_1[deduped_1_3][hoisted_1_2] * deduped_16_1[deduped_1_3];
                                end ))] ) ) );
             end ) ) );
 end

--- a/FunctorCategories/gap/precompiled_categories/FinBouquetsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinBouquetsPrecompiled.gi
@@ -96,78 +96,51 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, hoisted_11_1, hoisted_12_1, deduped_13_1, hoisted_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1;
-    deduped_27_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_26_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_25_1 := deduped_27_1[3];
-    deduped_24_1 := deduped_27_1[2];
-    deduped_23_1 := deduped_26_1[2];
-    deduped_22_1 := deduped_27_1[1];
-    deduped_21_1 := deduped_26_1[1];
-    deduped_20_1 := [ 0 .. deduped_23_1 - 1 ];
-    deduped_19_1 := Concatenation( ListWithIdenticalEntries( deduped_21_1, deduped_22_1 ), ListWithIdenticalEntries( deduped_23_1, deduped_24_1 ) );
-    deduped_18_1 := [ 0 .. Product( deduped_19_1 ) - 1 ];
-    hoisted_17_1 := List( deduped_20_1, function ( i_2 )
+    local hoisted_1_1, hoisted_4_1, hoisted_5_1, deduped_6_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1;
+    deduped_18_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_17_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_16_1 := deduped_17_1[2];
+    deduped_15_1 := deduped_18_1[1];
+    deduped_14_1 := deduped_17_1[1];
+    deduped_13_1 := [ 0 .. deduped_16_1 - 1 ];
+    deduped_12_1 := Concatenation( ListWithIdenticalEntries( deduped_14_1, deduped_15_1 ), ListWithIdenticalEntries( deduped_16_1, deduped_18_1[2] ) );
+    deduped_11_1 := [ 0 .. Product( deduped_12_1 ) - 1 ];
+    hoisted_9_1 := deduped_18_1[3];
+    hoisted_8_1 := [ deduped_14_1 .. deduped_14_1 + deduped_16_1 - 1 ];
+    hoisted_10_1 := List( deduped_13_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) + deduped_21_1);
-            hoisted_2_2 := deduped_19_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_19_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_18_1, function ( i_3 )
-                    return deduped_25_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+            deduped_3_2 := hoisted_8_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_12_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_12_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_11_1, function ( i_3 )
+                    return hoisted_9_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
                 end );
         end );
-    deduped_8_1 := [ deduped_22_1, deduped_24_1 ];
-    deduped_7_1 := [ 0, 1 ];
-    deduped_2_1 := Concatenation( ListWithIdenticalEntries( deduped_21_1, 0 ), ListWithIdenticalEntries( deduped_23_1, 1 ) );
-    deduped_1_1 := deduped_26_1[3];
-    hoisted_12_1 := List( deduped_20_1, function ( i_2 )
-            return deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_2_1[1 + deduped_1_1[(1 + i_2)]] )];
+    hoisted_5_1 := ListWithIdenticalEntries( deduped_16_1, deduped_15_1 );
+    deduped_6_1 := List( deduped_13_1, function ( j_2 )
+            return Product( hoisted_5_1{[ 1 .. j_2 ]} );
         end );
-    deduped_13_1 := List( deduped_20_1, function ( j_2 )
-            return Product( hoisted_12_1{[ 1 .. j_2 ]} );
-        end );
-    deduped_6_1 := [ 0, 1, 2 ];
-    deduped_5_1 := [ 0, 1, 1 ];
-    deduped_4_1 := [ 0, 0, 1 ];
-    deduped_3_1 := [ 0, 2 ];
-    hoisted_11_1 := List( deduped_20_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
-            deduped_7_2 := 1 + deduped_1_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ))];
-            deduped_6_2 := 1 + deduped_3_1[(1 + deduped_2_1[deduped_7_2])];
-            deduped_5_2 := deduped_4_1[deduped_6_2];
-            deduped_4_2 := 1 + deduped_3_1[(1 + deduped_5_2)];
-            hoisted_3_2 := CAP_JIT_INCOMPLETE_LOGIC( IdFunc( function (  )
-                        if IdFunc( function (  )
-                                    if deduped_5_2 = deduped_4_1[deduped_4_2] and deduped_5_1[deduped_6_2] = deduped_5_1[deduped_4_2] then
-                                        return deduped_6_1[deduped_6_2] = deduped_6_1[deduped_4_2];
-                                    else
-                                        return false;
-                                    fi;
-                                    return;
-                                end )(  ) then
-                            return [ 0 .. deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_5_2 )] - 1 ];
-                        else
-                            return deduped_25_1;
-                        fi;
-                        return;
-                    end )(  ) );
-            hoisted_2_2 := deduped_19_1[deduped_7_2];
-            hoisted_1_2 := Product( deduped_19_1{[ 1 .. deduped_7_2 - 1 ]} );
-            return List( deduped_18_1, function ( i_3 )
-                    return hoisted_3_2[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+    hoisted_1_1 := deduped_17_1[3];
+    hoisted_4_1 := List( deduped_13_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_12_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_12_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_11_1, function ( i_3 )
+                    return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_18_1, function ( x_2 )
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_11_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_20_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_13_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_11_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_20_1, function ( j_3 )
+                            return hoisted_4_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_13_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
+                            return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
                         end ) );
             end ) ) );
 end
@@ -180,87 +153,61 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, hoisted_11_1, hoisted_12_1, deduped_13_1, hoisted_17_1, hoisted_19_1, hoisted_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1;
-    deduped_33_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( range_1 );
-    deduped_32_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( source_1 );
-    deduped_31_1 := deduped_33_1[3];
-    deduped_30_1 := deduped_33_1[2];
-    deduped_29_1 := deduped_33_1[1];
-    deduped_28_1 := deduped_32_1[2];
-    deduped_27_1 := deduped_32_1[1];
-    deduped_26_1 := [ 0 .. deduped_28_1 - 1 ];
-    deduped_25_1 := Concatenation( ListWithIdenticalEntries( deduped_27_1, deduped_29_1 ), ListWithIdenticalEntries( deduped_28_1, deduped_30_1 ) );
-    deduped_24_1 := Product( deduped_25_1{[ 1 .. deduped_27_1 ]} );
-    deduped_23_1 := [ 0 .. Product( deduped_25_1 ) - 1 ];
-    hoisted_17_1 := List( deduped_26_1, function ( i_2 )
+    local hoisted_1_1, hoisted_4_1, hoisted_5_1, deduped_6_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_12_1, hoisted_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1;
+    deduped_25_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( range_1 );
+    deduped_24_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( source_1 );
+    deduped_23_1 := deduped_25_1[2];
+    deduped_22_1 := deduped_25_1[1];
+    deduped_21_1 := deduped_24_1[2];
+    deduped_20_1 := deduped_24_1[1];
+    deduped_19_1 := [ 0 .. deduped_21_1 - 1 ];
+    deduped_18_1 := Concatenation( ListWithIdenticalEntries( deduped_20_1, deduped_22_1 ), ListWithIdenticalEntries( deduped_21_1, deduped_23_1 ) );
+    deduped_17_1 := Product( deduped_18_1{[ 1 .. deduped_20_1 ]} );
+    deduped_16_1 := [ 0 .. Product( deduped_18_1 ) - 1 ];
+    hoisted_9_1 := deduped_25_1[3];
+    hoisted_8_1 := [ deduped_20_1 .. deduped_20_1 + deduped_21_1 - 1 ];
+    hoisted_10_1 := List( deduped_19_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) + deduped_27_1);
-            hoisted_2_2 := deduped_25_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_25_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_23_1, function ( i_3 )
-                    return deduped_31_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+            deduped_3_2 := hoisted_8_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_18_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_18_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_16_1, function ( i_3 )
+                    return hoisted_9_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
                 end );
         end );
-    deduped_8_1 := [ deduped_29_1, deduped_30_1 ];
-    deduped_7_1 := [ 0, 1 ];
-    deduped_2_1 := Concatenation( ListWithIdenticalEntries( deduped_27_1, 0 ), ListWithIdenticalEntries( deduped_28_1, 1 ) );
-    deduped_1_1 := deduped_32_1[3];
-    hoisted_12_1 := List( deduped_26_1, function ( i_2 )
-            return deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_2_1[1 + deduped_1_1[(1 + i_2)]] )];
+    hoisted_5_1 := ListWithIdenticalEntries( deduped_21_1, deduped_22_1 );
+    deduped_6_1 := List( deduped_19_1, function ( j_2 )
+            return Product( hoisted_5_1{[ 1 .. j_2 ]} );
         end );
-    deduped_13_1 := List( deduped_26_1, function ( j_2 )
-            return Product( hoisted_12_1{[ 1 .. j_2 ]} );
-        end );
-    deduped_6_1 := [ 0, 1, 2 ];
-    deduped_5_1 := [ 0, 1, 1 ];
-    deduped_4_1 := [ 0, 0, 1 ];
-    deduped_3_1 := [ 0, 2 ];
-    hoisted_11_1 := List( deduped_26_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
-            deduped_7_2 := 1 + deduped_1_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ))];
-            deduped_6_2 := 1 + deduped_3_1[(1 + deduped_2_1[deduped_7_2])];
-            deduped_5_2 := deduped_4_1[deduped_6_2];
-            deduped_4_2 := 1 + deduped_3_1[(1 + deduped_5_2)];
-            hoisted_3_2 := CAP_JIT_INCOMPLETE_LOGIC( IdFunc( function (  )
-                        if IdFunc( function (  )
-                                    if deduped_5_2 = deduped_4_1[deduped_4_2] and deduped_5_1[deduped_6_2] = deduped_5_1[deduped_4_2] then
-                                        return deduped_6_1[deduped_6_2] = deduped_6_1[deduped_4_2];
-                                    else
-                                        return false;
-                                    fi;
-                                    return;
-                                end )(  ) then
-                            return [ 0 .. deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_5_2 )] - 1 ];
-                        else
-                            return deduped_31_1;
-                        fi;
-                        return;
-                    end )(  ) );
-            hoisted_2_2 := deduped_25_1[deduped_7_2];
-            hoisted_1_2 := Product( deduped_25_1{[ 1 .. deduped_7_2 - 1 ]} );
-            return List( deduped_23_1, function ( i_3 )
-                    return hoisted_3_2[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+    hoisted_1_1 := deduped_24_1[3];
+    hoisted_4_1 := List( deduped_19_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_18_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_18_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_16_1, function ( i_3 )
+                    return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    deduped_22_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_23_1, function ( x_2 )
+    deduped_15_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_16_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_26_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_19_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_11_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_26_1, function ( j_3 )
+                            return hoisted_4_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_19_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
+                            return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
                         end ) );
             end )[1 + AsList( alpha_1 )[(1 + CAP_JIT_INCOMPLETE_LOGIC( [ 0 .. (Length( Source( alpha_1 ) ) - 1) ][1] ))]] );
-    hoisted_21_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_22_1, deduped_24_1 ), Product( deduped_25_1{[ 1 + deduped_27_1 .. Sum( [ deduped_27_1, deduped_28_1 ]{[ 1, 2 ]} ) ]} ) ) );
-    hoisted_19_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_22_1, deduped_24_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfBouquetMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( [ 0 .. deduped_27_1 - 1 ], function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_19_1, deduped_29_1 ^ i_2 ), deduped_29_1 );
-            end ), List( deduped_26_1, function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_21_1, deduped_30_1 ^ i_2 ), deduped_30_1 );
+    hoisted_14_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_15_1, deduped_17_1 ), Product( deduped_18_1{[ 1 + deduped_20_1 .. Sum( [ deduped_20_1, deduped_21_1 ]{[ 1, 2 ]} ) ]} ) ) );
+    hoisted_12_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_15_1, deduped_17_1 ) );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfBouquetMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( [ 0 .. deduped_20_1 - 1 ], function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_12_1, deduped_22_1 ^ i_2 ), deduped_22_1 );
+            end ), List( deduped_19_1, function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_14_1, deduped_23_1 ^ i_2 ), deduped_23_1 );
             end ) ) );
 end
 ########
@@ -272,93 +219,67 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, hoisted_11_1, hoisted_12_1, deduped_13_1, hoisted_17_1, deduped_20_1, hoisted_22_1, hoisted_23_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1;
-    deduped_36_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_35_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_34_1 := deduped_36_1[3];
-    deduped_33_1 := deduped_36_1[2];
-    deduped_32_1 := deduped_35_1[2];
-    deduped_31_1 := deduped_36_1[1];
-    deduped_30_1 := deduped_35_1[1];
-    deduped_29_1 := [ 0 .. deduped_32_1 - 1 ];
-    deduped_28_1 := Concatenation( ListWithIdenticalEntries( deduped_30_1, deduped_31_1 ), ListWithIdenticalEntries( deduped_32_1, deduped_33_1 ) );
-    deduped_27_1 := [ 0 .. Product( deduped_28_1 ) - 1 ];
-    hoisted_17_1 := List( deduped_29_1, function ( i_2 )
+    local hoisted_1_1, hoisted_4_1, hoisted_5_1, deduped_6_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, deduped_13_1, hoisted_15_1, hoisted_16_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1;
+    deduped_28_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_27_1 := DefiningTripleOfBouquetEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_26_1 := deduped_28_1[2];
+    deduped_25_1 := deduped_27_1[2];
+    deduped_24_1 := deduped_28_1[1];
+    deduped_23_1 := deduped_27_1[1];
+    deduped_22_1 := [ 0 .. deduped_25_1 - 1 ];
+    deduped_21_1 := Concatenation( ListWithIdenticalEntries( deduped_23_1, deduped_24_1 ), ListWithIdenticalEntries( deduped_25_1, deduped_26_1 ) );
+    deduped_20_1 := [ 0 .. Product( deduped_21_1 ) - 1 ];
+    hoisted_9_1 := deduped_28_1[3];
+    hoisted_8_1 := [ deduped_23_1 .. deduped_23_1 + deduped_25_1 - 1 ];
+    hoisted_10_1 := List( deduped_22_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (CAP_JIT_INCOMPLETE_LOGIC( i_2 ) + deduped_30_1);
-            hoisted_2_2 := deduped_28_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_28_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_27_1, function ( i_3 )
-                    return deduped_34_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+            deduped_3_2 := hoisted_8_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_21_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_21_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_20_1, function ( i_3 )
+                    return hoisted_9_1[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
                 end );
         end );
-    deduped_8_1 := [ deduped_31_1, deduped_33_1 ];
-    deduped_7_1 := [ 0, 1 ];
-    deduped_2_1 := Concatenation( ListWithIdenticalEntries( deduped_30_1, 0 ), ListWithIdenticalEntries( deduped_32_1, 1 ) );
-    deduped_1_1 := deduped_35_1[3];
-    hoisted_12_1 := List( deduped_29_1, function ( i_2 )
-            return deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_2_1[1 + deduped_1_1[(1 + i_2)]] )];
+    hoisted_5_1 := ListWithIdenticalEntries( deduped_25_1, deduped_24_1 );
+    deduped_6_1 := List( deduped_22_1, function ( j_2 )
+            return Product( hoisted_5_1{[ 1 .. j_2 ]} );
         end );
-    deduped_13_1 := List( deduped_29_1, function ( j_2 )
-            return Product( hoisted_12_1{[ 1 .. j_2 ]} );
-        end );
-    deduped_6_1 := [ 0, 1, 2 ];
-    deduped_5_1 := [ 0, 1, 1 ];
-    deduped_4_1 := [ 0, 0, 1 ];
-    deduped_3_1 := [ 0, 2 ];
-    hoisted_11_1 := List( deduped_29_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2;
-            deduped_7_2 := 1 + deduped_1_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ))];
-            deduped_6_2 := 1 + deduped_3_1[(1 + deduped_2_1[deduped_7_2])];
-            deduped_5_2 := deduped_4_1[deduped_6_2];
-            deduped_4_2 := 1 + deduped_3_1[(1 + deduped_5_2)];
-            hoisted_3_2 := CAP_JIT_INCOMPLETE_LOGIC( IdFunc( function (  )
-                        if IdFunc( function (  )
-                                    if deduped_5_2 = deduped_4_1[deduped_4_2] and deduped_5_1[deduped_6_2] = deduped_5_1[deduped_4_2] then
-                                        return deduped_6_1[deduped_6_2] = deduped_6_1[deduped_4_2];
-                                    else
-                                        return false;
-                                    fi;
-                                    return;
-                                end )(  ) then
-                            return [ 0 .. deduped_8_1[SafeUniquePosition( deduped_7_1, deduped_5_2 )] - 1 ];
-                        else
-                            return deduped_34_1;
-                        fi;
-                        return;
-                    end )(  ) );
-            hoisted_2_2 := deduped_28_1[deduped_7_2];
-            hoisted_1_2 := Product( deduped_28_1{[ 1 .. deduped_7_2 - 1 ]} );
-            return List( deduped_27_1, function ( i_3 )
-                    return hoisted_3_2[1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) )];
+    hoisted_1_1 := deduped_27_1[3];
+    hoisted_4_1 := List( deduped_22_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := hoisted_1_1[1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 )];
+            hoisted_2_2 := deduped_21_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_21_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_20_1, function ( i_3 )
+                    return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    deduped_26_1 := Filtered( deduped_27_1, function ( x_2 )
+    deduped_19_1 := Filtered( deduped_20_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_22_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_11_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+                        return hoisted_4_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_22_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_13_1[deduped_1_3];
+                        return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_6_1[deduped_1_3];
                     end ) );
         end );
-    deduped_25_1 := Length( deduped_26_1 );
-    hoisted_23_1 := Product( deduped_28_1{[ 1 + deduped_30_1 .. Sum( [ deduped_30_1, deduped_32_1 ]{[ 1, 2 ]} ) ]} );
-    hoisted_22_1 := [ 0 .. deduped_30_1 - 1 ];
-    deduped_20_1 := Product( deduped_28_1{[ 1 .. deduped_30_1 ]} );
-    return List( [ 0 .. deduped_25_1 - 1 ], function ( i_2 )
+    deduped_18_1 := Length( deduped_19_1 );
+    hoisted_16_1 := Product( deduped_21_1{[ 1 + deduped_23_1 .. Sum( [ deduped_23_1, deduped_25_1 ]{[ 1, 2 ]} ) ]} );
+    hoisted_15_1 := [ 0 .. deduped_23_1 - 1 ];
+    deduped_13_1 := Product( deduped_21_1{[ 1 .. deduped_23_1 ]} );
+    return List( [ 0 .. deduped_18_1 - 1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_26_1[1 + REM_INT( i_2, deduped_25_1 )] );
-            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_20_1 ), hoisted_23_1 ) );
-            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_20_1 ) );
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfBouquetMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( hoisted_22_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_1_2, deduped_31_1 ^ i_3 ), deduped_31_1 );
-                    end ), List( deduped_29_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_2_2, deduped_33_1 ^ i_3 ), deduped_33_1 );
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_19_1[1 + REM_INT( i_2, deduped_18_1 )] );
+            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_13_1 ), hoisted_16_1 ) );
+            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_13_1 ) );
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfBouquetMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( hoisted_15_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_1_2, deduped_24_1 ^ i_3 ), deduped_24_1 );
+                    end ), List( deduped_22_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_2_2, deduped_26_1 ^ i_3 ), deduped_26_1 );
                     end ) ) );
         end );
 end

--- a/FunctorCategories/gap/precompiled_categories/FinQuiversAsCCCPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinQuiversAsCCCPrecompiled.gi
@@ -10,56 +10,57 @@ BindGlobal( "ADD_FUNCTIONS_FOR_FinQuiversAsCCCPrecompiled", function ( cat )
         
 ########
 function ( cat_1, a_1, b_1 )
-    local deduped_1_1, hoisted_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, hoisted_14_1, deduped_15_1, hoisted_16_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, deduped_22_1, hoisted_24_1, hoisted_26_1, hoisted_27_1, hoisted_31_1, deduped_32_1, hoisted_34_1, deduped_36_1, hoisted_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1, deduped_66_1;
-    deduped_66_1 := UnderlyingCategory( cat_1 );
-    deduped_65_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( b_1 );
-    deduped_64_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( a_1 );
-    deduped_63_1 := deduped_65_1[3];
-    deduped_62_1 := CreateCapCategoryObjectWithAttributes( deduped_66_1, IndexOfObject, 1 );
-    deduped_61_1 := CreateCapCategoryObjectWithAttributes( deduped_66_1, IndexOfObject, 0 );
-    deduped_60_1 := deduped_64_1[3];
-    deduped_59_1 := deduped_65_1[2];
-    deduped_58_1 := deduped_64_1[2];
-    deduped_57_1 := deduped_65_1[1];
-    deduped_56_1 := deduped_64_1[1];
-    deduped_55_1 := 2 * deduped_56_1;
-    deduped_54_1 := ListWithIdenticalEntries( deduped_56_1, deduped_57_1 );
-    deduped_53_1 := [ 0 .. deduped_56_1 - 1 ];
-    deduped_52_1 := [ 0 .. deduped_58_1 - 1 ];
-    deduped_51_1 := [ List( deduped_63_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_4_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, deduped_11_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_20_1, deduped_21_1, hoisted_23_1, deduped_25_1, hoisted_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1;
+    deduped_55_1 := UnderlyingCategory( cat_1 );
+    deduped_54_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( b_1 );
+    deduped_53_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( a_1 );
+    deduped_52_1 := CreateCapCategoryObjectWithAttributes( deduped_55_1, IndexOfObject, 1 );
+    deduped_51_1 := CreateCapCategoryObjectWithAttributes( deduped_55_1, IndexOfObject, 0 );
+    deduped_50_1 := deduped_54_1[3];
+    deduped_49_1 := deduped_53_1[3];
+    deduped_48_1 := deduped_53_1[2];
+    deduped_47_1 := deduped_54_1[1];
+    deduped_46_1 := deduped_53_1[1];
+    deduped_45_1 := ListWithIdenticalEntries( deduped_48_1, deduped_47_1 );
+    deduped_44_1 := 2 * deduped_46_1;
+    deduped_43_1 := ListWithIdenticalEntries( deduped_46_1, deduped_47_1 );
+    deduped_42_1 := [ 0 .. deduped_46_1 - 1 ];
+    deduped_41_1 := [ 0 .. deduped_48_1 - 1 ];
+    deduped_40_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_55_1, deduped_51_1, deduped_52_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_55_1, deduped_51_1, deduped_52_1, IndexOfMorphism, 2 ) ];
+    deduped_39_1 := [ List( deduped_50_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_63_1, function ( a_2 )
+            end ), List( deduped_50_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_50_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_66_1, deduped_61_1, deduped_62_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_66_1, deduped_61_1, deduped_62_1, IndexOfMorphism, 2 ) ];
-    deduped_49_1 := [ 0 .. deduped_58_1 + deduped_58_1 - 1 ];
-    deduped_48_1 := Concatenation( ListWithIdenticalEntries( deduped_55_1, deduped_57_1 ), ListWithIdenticalEntries( deduped_58_1, deduped_59_1 ) );
-    deduped_47_1 := [ 0 .. Product( deduped_54_1 ) - 1 ];
-    deduped_46_1 := [ 0 .. Length( deduped_53_1 ) - 1 ];
-    deduped_45_1 := Product( deduped_48_1 );
-    deduped_44_1 := Filtered( deduped_47_1, function ( x_2 )
-            return true;
-        end );
-    deduped_43_1 := ListWithIdenticalEntries( Length( deduped_52_1 ), deduped_45_1 );
-    deduped_42_1 := [ 0 .. deduped_45_1 - 1 ];
-    deduped_41_1 := List( deduped_52_1, function ( i_2 )
+    deduped_38_1 := [ 0 .. deduped_48_1 + deduped_48_1 - 1 ];
+    deduped_37_1 := ListWithIdenticalEntries( deduped_48_1, [ 0 .. deduped_47_1 - 1 ] );
+    deduped_36_1 := Concatenation( ListWithIdenticalEntries( deduped_44_1, deduped_47_1 ), ListWithIdenticalEntries( deduped_48_1, deduped_54_1[2] ) );
+    deduped_35_1 := [ 0 .. Product( deduped_43_1 ) - 1 ];
+    deduped_34_1 := Product( deduped_36_1 );
+    deduped_30_1 := [ 0 .. deduped_34_1 - 1 ];
+    hoisted_14_1 := [ deduped_44_1 .. deduped_44_1 + deduped_48_1 - 1 ];
+    deduped_33_1 := List( deduped_41_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_55_1);
-            hoisted_2_2 := deduped_48_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_48_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_42_1, function ( i_3 )
+            deduped_3_2 := hoisted_14_1[1 + i_2];
+            hoisted_2_2 := deduped_36_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_30_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_26_1 := Concatenation( deduped_41_1, deduped_41_1 );
-    hoisted_24_1 := Concatenation( ListWithIdenticalEntries( deduped_58_1, deduped_51_1[SafeUniquePositionProperty( deduped_50_1, function ( mor_2 )
+    deduped_32_1 := Filtered( deduped_35_1, function ( x_2 )
+            return true;
+        end );
+    deduped_31_1 := ListWithIdenticalEntries( deduped_48_1, deduped_34_1 );
+    hoisted_15_1 := Concatenation( deduped_33_1, deduped_33_1 );
+    hoisted_13_1 := Concatenation( ListWithIdenticalEntries( deduped_48_1, deduped_39_1[SafeUniquePositionProperty( deduped_40_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_58_1, deduped_51_1[SafeUniquePositionProperty( deduped_50_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_48_1, deduped_39_1[SafeUniquePositionProperty( deduped_40_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
@@ -67,186 +68,115 @@ function ( cat_1, a_1, b_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( deduped_43_1, deduped_43_1 );
-    hoisted_27_1 := List( deduped_49_1, function ( i_2 )
+    deduped_1_1 := Concatenation( deduped_31_1, deduped_31_1 );
+    hoisted_16_1 := List( deduped_38_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_24_1[deduped_3_2];
-            hoisted_1_2 := hoisted_26_1[deduped_3_2];
+            hoisted_2_2 := hoisted_13_1[deduped_3_2];
+            hoisted_1_2 := hoisted_15_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_14_1 := List( deduped_60_1, function ( a_2 )
+    hoisted_10_1 := Concatenation( deduped_45_1, deduped_45_1 );
+    deduped_11_1 := List( deduped_38_1, function ( j_2 )
+            return Product( hoisted_10_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_7_1 := List( deduped_49_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_15_1 := List( deduped_52_1, function ( i_2 )
-            return 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_14_1[(1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_58_1 ))] ) * 2;
-        end );
-    deduped_11_1 := [ deduped_57_1, deduped_59_1 ];
-    deduped_10_1 := [ 0, 1 ];
-    deduped_5_1 := Concatenation( ListWithIdenticalEntries( deduped_55_1, 0 ), ListWithIdenticalEntries( deduped_58_1, 1 ) );
-    hoisted_3_1 := List( deduped_60_1, function ( a_2 )
+    hoisted_4_1 := List( deduped_49_1, function ( a_2 )
             return a_2[1];
         end );
-    deduped_4_1 := List( deduped_52_1, function ( i_2 )
-            return CAP_JIT_INCOMPLETE_LOGIC( hoisted_3_1[(1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_58_1 ))] ) * 2;
-        end );
-    hoisted_21_1 := Concatenation( List( deduped_52_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_1[1 + deduped_4_1[(1 + i_2)]] )];
-          end ), List( deduped_52_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_1[1 + deduped_15_1[(1 + i_2)]] )];
-          end ) );
-    deduped_22_1 := List( deduped_49_1, function ( j_2 )
-            return Product( hoisted_21_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_19_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+    hoisted_8_1 := Concatenation( List( deduped_41_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_4_1[(1 + i_2)];
-              hoisted_2_2 := deduped_48_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_48_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_42_1, function ( i_3 )
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( hoisted_4_1[(1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_48_1 ))] ) * 2 );
+              hoisted_2_2 := deduped_36_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_30_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_52_1, function ( i_2 )
+          end ), List( deduped_41_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_15_1[(1 + i_2)];
-              hoisted_2_2 := deduped_48_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_48_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_42_1, function ( i_3 )
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( 1 + CAP_JIT_INCOMPLETE_LOGIC( hoisted_7_1[(1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_48_1 ))] ) * 2 );
+              hoisted_2_2 := deduped_36_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_30_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_9_1 := [ 0, 1, 2, 3 ];
-    deduped_8_1 := [ 0, 1, 1, 1 ];
-    deduped_7_1 := [ 0, 0, 0, 1 ];
-    deduped_6_1 := [ 0, 3 ];
-    hoisted_16_1 := Concatenation( List( deduped_52_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_5_1[(1 + deduped_4_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_51_1[SafeUniquePositionProperty( deduped_50_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_52_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_5_1[(1 + deduped_15_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_51_1[SafeUniquePositionProperty( deduped_50_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_20_1 := List( deduped_49_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( deduped_37_1, deduped_37_1 );
+    hoisted_9_1 := List( deduped_38_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_16_1[deduped_3_2];
-            hoisted_1_2 := hoisted_19_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_8_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_40_1 := Filtered( deduped_42_1, function ( x_2 )
+    deduped_29_1 := Filtered( deduped_30_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_49_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_38_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_20_1[deduped_1_3][deduped_1_2] * deduped_22_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_49_1, function ( j_3 )
+                        return hoisted_9_1[deduped_1_3][deduped_1_2] * deduped_11_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_38_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_27_1[deduped_1_3][deduped_1_2] * deduped_22_1[deduped_1_3];
+                        return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_11_1[deduped_1_3];
                     end ) );
         end );
-    deduped_39_1 := Length( deduped_40_1 );
-    hoisted_38_1 := List( deduped_46_1, function ( i_2 )
+    deduped_28_1 := Length( deduped_29_1 );
+    hoisted_27_1 := List( deduped_42_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( (1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2) );
-            hoisted_2_2 := deduped_48_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_48_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_42_1, function ( i_3 )
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( 1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
+            hoisted_2_2 := deduped_36_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_30_1, function ( i_3 )
                     return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    deduped_32_1 := List( deduped_53_1, function ( j_2 )
-            return Product( deduped_54_1{[ 1 .. j_2 ]} );
+    deduped_21_1 := List( deduped_42_1, function ( j_2 )
+            return Product( deduped_43_1{[ 1 .. j_2 ]} );
         end );
-    hoisted_31_1 := List( [ 1 .. deduped_56_1 ], function ( i_2 )
+    hoisted_20_1 := List( [ 1 .. deduped_46_1 ], function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := Product( deduped_54_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_47_1, function ( i_3 )
-                    return REM_INT( QUO_INT( i_3, hoisted_1_2 ), deduped_57_1 );
+            hoisted_1_2 := Product( deduped_43_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_35_1, function ( i_3 )
+                    return REM_INT( QUO_INT( i_3, hoisted_1_2 ), deduped_47_1 );
                 end );
         end );
-    deduped_36_1 := List( deduped_47_1, function ( i_2 )
+    deduped_25_1 := List( deduped_35_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_53_1, function ( j_3 )
+            return Sum( deduped_42_1, function ( j_3 )
                     local deduped_1_3;
                     deduped_1_3 := 1 + j_3;
-                    return hoisted_31_1[deduped_1_3][hoisted_1_2] * deduped_32_1[deduped_1_3];
+                    return hoisted_20_1[deduped_1_3][hoisted_1_2] * deduped_21_1[deduped_1_3];
                 end );
         end );
-    hoisted_34_1 := List( deduped_46_1, function ( i_2 )
+    hoisted_23_1 := List( deduped_42_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
-            hoisted_2_2 := deduped_48_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_48_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_42_1, function ( i_3 )
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
+            hoisted_2_2 := deduped_36_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_30_1, function ( i_3 )
                     return CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_3 ), hoisted_1_2 ), hoisted_2_2 ) );
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfQuiverEnrichedOverSkeletalFinSets, NTuple( 3, Length( deduped_44_1 ), deduped_39_1, List( [ 0 .. deduped_39_1 - 1 ], function ( x_2 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningTripleOfQuiverEnrichedOverSkeletalFinSets, NTuple( 3, Length( deduped_32_1 ), deduped_28_1, List( [ 0 .. deduped_28_1 - 1 ], function ( x_2 )
                 local deduped_1_2;
-                deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_40_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
-                return NTuple( 2, -1 + BigInt( SafePosition( deduped_44_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_36_1[(1 + Sum( deduped_53_1, function ( j_3 )
+                deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_29_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
+                return NTuple( 2, -1 + BigInt( SafePosition( deduped_32_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_25_1[(1 + Sum( deduped_42_1, function ( j_3 )
                                      local deduped_1_3;
                                      deduped_1_3 := (1 + j_3);
-                                     return hoisted_34_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
-                                 end ))] ) ) ), -1 + BigInt( SafePosition( deduped_44_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_36_1[(1 + Sum( deduped_53_1, function ( j_3 )
+                                     return hoisted_23_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
+                                 end ))] ) ) ), -1 + BigInt( SafePosition( deduped_32_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_25_1[(1 + Sum( deduped_42_1, function ( j_3 )
                                      local deduped_1_3;
                                      deduped_1_3 := (1 + j_3);
-                                     return hoisted_38_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
+                                     return hoisted_27_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
                                  end ))] ) ) ) );
             end ) ) );
 end

--- a/FunctorCategories/gap/precompiled_categories/FinQuiversPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinQuiversPrecompiled.gi
@@ -75,48 +75,50 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_12_1, hoisted_13_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, hoisted_21_1, hoisted_23_1, hoisted_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1;
-    deduped_44_1 := UnderlyingCategory( cat_1 );
-    deduped_43_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_42_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_41_1 := deduped_43_1[3];
-    deduped_40_1 := CreateCapCategoryObjectWithAttributes( deduped_44_1, IndexOfObject, 1 );
-    deduped_39_1 := CreateCapCategoryObjectWithAttributes( deduped_44_1, IndexOfObject, 0 );
-    deduped_38_1 := deduped_42_1[3];
-    deduped_37_1 := deduped_43_1[2];
-    deduped_36_1 := deduped_42_1[2];
-    deduped_35_1 := deduped_43_1[1];
-    deduped_34_1 := deduped_42_1[1];
-    deduped_33_1 := [ 0 .. deduped_36_1 - 1 ];
-    deduped_32_1 := [ List( deduped_41_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, deduped_10_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1;
+    deduped_36_1 := UnderlyingCategory( cat_1 );
+    deduped_35_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_34_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_33_1 := CreateCapCategoryObjectWithAttributes( deduped_36_1, IndexOfObject, 1 );
+    deduped_32_1 := CreateCapCategoryObjectWithAttributes( deduped_36_1, IndexOfObject, 0 );
+    deduped_31_1 := deduped_35_1[3];
+    deduped_30_1 := deduped_34_1[3];
+    deduped_29_1 := deduped_34_1[2];
+    deduped_28_1 := deduped_35_1[1];
+    deduped_27_1 := deduped_34_1[1];
+    deduped_26_1 := ListWithIdenticalEntries( deduped_29_1, deduped_28_1 );
+    deduped_25_1 := [ 0 .. deduped_29_1 - 1 ];
+    deduped_24_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_36_1, deduped_32_1, deduped_33_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_36_1, deduped_32_1, deduped_33_1, IndexOfMorphism, 2 ) ];
+    deduped_23_1 := [ List( deduped_31_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_41_1, function ( a_2 )
+            end ), List( deduped_31_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_31_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_44_1, deduped_39_1, deduped_40_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_44_1, deduped_39_1, deduped_40_1, IndexOfMorphism, 2 ) ];
-    deduped_30_1 := Concatenation( ListWithIdenticalEntries( deduped_34_1, deduped_35_1 ), ListWithIdenticalEntries( deduped_36_1, deduped_37_1 ) );
-    deduped_29_1 := [ 0 .. deduped_36_1 + deduped_36_1 - 1 ];
-    deduped_28_1 := Product( deduped_30_1 );
-    deduped_27_1 := ListWithIdenticalEntries( Length( deduped_33_1 ), deduped_28_1 );
-    deduped_26_1 := [ 0 .. deduped_28_1 - 1 ];
-    deduped_25_1 := List( deduped_33_1, function ( i_2 )
+    deduped_22_1 := Concatenation( ListWithIdenticalEntries( deduped_27_1, deduped_28_1 ), ListWithIdenticalEntries( deduped_29_1, deduped_35_1[2] ) );
+    deduped_21_1 := [ 0 .. deduped_29_1 + deduped_29_1 - 1 ];
+    deduped_20_1 := ListWithIdenticalEntries( deduped_29_1, [ 0 .. deduped_28_1 - 1 ] );
+    deduped_19_1 := Product( deduped_22_1 );
+    deduped_18_1 := ListWithIdenticalEntries( deduped_29_1, deduped_19_1 );
+    deduped_17_1 := [ 0 .. deduped_19_1 - 1 ];
+    hoisted_13_1 := [ deduped_27_1 .. deduped_27_1 + deduped_29_1 - 1 ];
+    deduped_16_1 := List( deduped_25_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_34_1);
-            hoisted_2_2 := deduped_30_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_30_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_26_1, function ( i_3 )
+            deduped_3_2 := hoisted_13_1[1 + i_2];
+            hoisted_2_2 := deduped_22_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_22_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_17_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_23_1 := Concatenation( deduped_25_1, deduped_25_1 );
-    hoisted_21_1 := Concatenation( ListWithIdenticalEntries( deduped_36_1, deduped_32_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_2 )
+    hoisted_14_1 := Concatenation( deduped_16_1, deduped_16_1 );
+    hoisted_12_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, deduped_23_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_36_1, deduped_32_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_29_1, deduped_23_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
@@ -124,129 +126,64 @@ function ( cat_1, arg2_1, arg3_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( deduped_27_1, deduped_27_1 );
-    hoisted_24_1 := List( deduped_29_1, function ( i_2 )
+    deduped_1_1 := Concatenation( deduped_18_1, deduped_18_1 );
+    hoisted_15_1 := List( deduped_21_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_21_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
+            hoisted_2_2 := hoisted_12_1[deduped_3_2];
+            hoisted_1_2 := hoisted_14_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_12_1 := List( deduped_38_1, function ( a_2 )
+    hoisted_9_1 := Concatenation( deduped_26_1, deduped_26_1 );
+    deduped_10_1 := List( deduped_21_1, function ( j_2 )
+            return Product( hoisted_9_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_6_1 := List( deduped_30_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_9_1 := [ deduped_35_1, deduped_37_1 ];
-    deduped_8_1 := [ 0, 1 ];
-    deduped_3_1 := Concatenation( ListWithIdenticalEntries( deduped_34_1, 0 ), ListWithIdenticalEntries( deduped_36_1, 1 ) );
-    deduped_2_1 := List( deduped_38_1, function ( a_2 )
+    hoisted_3_1 := List( deduped_30_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_18_1 := Concatenation( List( deduped_33_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_2_1[(1 + i_2)]] )];
-          end ), List( deduped_33_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_12_1[(1 + i_2)]] )];
-          end ) );
-    deduped_19_1 := List( deduped_29_1, function ( j_2 )
-            return Product( hoisted_18_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_16_1 := Concatenation( List( deduped_33_1, function ( i_2 )
+    hoisted_7_1 := Concatenation( List( deduped_25_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_2_1[(1 + i_2)];
-              hoisted_2_2 := deduped_30_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_30_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_26_1, function ( i_3 )
+              deduped_3_2 := hoisted_3_1[1 + i_2];
+              hoisted_2_2 := deduped_22_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_22_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_17_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_33_1, function ( i_2 )
+          end ), List( deduped_25_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_12_1[(1 + i_2)];
-              hoisted_2_2 := deduped_30_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_30_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_26_1, function ( i_3 )
+              deduped_3_2 := hoisted_6_1[1 + i_2];
+              hoisted_2_2 := deduped_22_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_22_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_17_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_7_1 := [ 0, 1, 2, 3 ];
-    deduped_6_1 := [ 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 0, 0, 1 ];
-    deduped_4_1 := [ 0, 3 ];
-    hoisted_13_1 := Concatenation( List( deduped_33_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_2_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_32_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_33_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_12_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_32_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_17_1 := List( deduped_29_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( deduped_20_1, deduped_20_1 );
+    hoisted_8_1 := List( deduped_21_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_13_1[deduped_3_2];
-            hoisted_1_2 := hoisted_16_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_7_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_26_1, function ( x_2 )
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_17_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_21_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+                            return hoisted_8_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_21_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
+                            return hoisted_15_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
                         end ) );
             end ) ) );
 end
@@ -259,49 +196,52 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_12_1, hoisted_13_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, hoisted_21_1, hoisted_23_1, hoisted_24_1, hoisted_26_1, hoisted_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1;
-    deduped_50_1 := UnderlyingCategory( cat_1 );
-    deduped_49_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( range_1 );
-    deduped_48_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( source_1 );
-    deduped_47_1 := deduped_49_1[3];
-    deduped_46_1 := CreateCapCategoryObjectWithAttributes( deduped_50_1, IndexOfObject, 1 );
-    deduped_45_1 := CreateCapCategoryObjectWithAttributes( deduped_50_1, IndexOfObject, 0 );
-    deduped_44_1 := deduped_48_1[3];
-    deduped_43_1 := deduped_49_1[2];
-    deduped_42_1 := deduped_49_1[1];
-    deduped_41_1 := deduped_48_1[2];
-    deduped_40_1 := deduped_48_1[1];
-    deduped_39_1 := [ 0 .. deduped_41_1 - 1 ];
-    deduped_38_1 := [ List( deduped_47_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, deduped_10_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, hoisted_17_1, hoisted_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1;
+    deduped_43_1 := UnderlyingCategory( cat_1 );
+    deduped_42_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( range_1 );
+    deduped_41_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( source_1 );
+    deduped_40_1 := CreateCapCategoryObjectWithAttributes( deduped_43_1, IndexOfObject, 1 );
+    deduped_39_1 := CreateCapCategoryObjectWithAttributes( deduped_43_1, IndexOfObject, 0 );
+    deduped_38_1 := deduped_42_1[3];
+    deduped_37_1 := deduped_41_1[3];
+    deduped_36_1 := deduped_42_1[2];
+    deduped_35_1 := deduped_42_1[1];
+    deduped_34_1 := deduped_41_1[2];
+    deduped_33_1 := deduped_41_1[1];
+    deduped_32_1 := ListWithIdenticalEntries( deduped_34_1, deduped_35_1 );
+    deduped_31_1 := [ 0 .. deduped_34_1 - 1 ];
+    deduped_30_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_43_1, deduped_39_1, deduped_40_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_43_1, deduped_39_1, deduped_40_1, IndexOfMorphism, 2 ) ];
+    deduped_29_1 := [ List( deduped_38_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_47_1, function ( a_2 )
+            end ), List( deduped_38_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_37_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_50_1, deduped_45_1, deduped_46_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_50_1, deduped_45_1, deduped_46_1, IndexOfMorphism, 2 ) ];
-    deduped_36_1 := Concatenation( ListWithIdenticalEntries( deduped_40_1, deduped_42_1 ), ListWithIdenticalEntries( deduped_41_1, deduped_43_1 ) );
-    deduped_35_1 := [ 0 .. deduped_41_1 + deduped_41_1 - 1 ];
-    deduped_34_1 := Product( deduped_36_1 );
-    deduped_33_1 := Product( deduped_36_1{[ 1 .. deduped_40_1 ]} );
-    deduped_32_1 := ListWithIdenticalEntries( Length( deduped_39_1 ), deduped_34_1 );
-    deduped_31_1 := [ 0 .. deduped_34_1 - 1 ];
-    deduped_30_1 := List( deduped_39_1, function ( i_2 )
+    deduped_28_1 := Concatenation( ListWithIdenticalEntries( deduped_33_1, deduped_35_1 ), ListWithIdenticalEntries( deduped_34_1, deduped_36_1 ) );
+    deduped_27_1 := [ 0 .. deduped_34_1 + deduped_34_1 - 1 ];
+    deduped_26_1 := ListWithIdenticalEntries( deduped_34_1, [ 0 .. deduped_35_1 - 1 ] );
+    deduped_25_1 := Product( deduped_28_1 );
+    deduped_24_1 := Product( deduped_28_1{[ 1 .. deduped_33_1 ]} );
+    deduped_23_1 := ListWithIdenticalEntries( deduped_34_1, deduped_25_1 );
+    deduped_22_1 := [ 0 .. deduped_25_1 - 1 ];
+    hoisted_13_1 := [ deduped_33_1 .. deduped_33_1 + deduped_34_1 - 1 ];
+    deduped_21_1 := List( deduped_31_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_40_1);
-            hoisted_2_2 := deduped_36_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_31_1, function ( i_3 )
+            deduped_3_2 := hoisted_13_1[1 + i_2];
+            hoisted_2_2 := deduped_28_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_28_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_22_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_23_1 := Concatenation( deduped_30_1, deduped_30_1 );
-    hoisted_21_1 := Concatenation( ListWithIdenticalEntries( deduped_41_1, deduped_38_1[SafeUniquePositionProperty( deduped_37_1, function ( mor_2 )
+    hoisted_14_1 := Concatenation( deduped_21_1, deduped_21_1 );
+    hoisted_12_1 := Concatenation( ListWithIdenticalEntries( deduped_34_1, deduped_29_1[SafeUniquePositionProperty( deduped_30_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_41_1, deduped_38_1[SafeUniquePositionProperty( deduped_37_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_34_1, deduped_29_1[SafeUniquePositionProperty( deduped_30_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
@@ -309,137 +249,72 @@ function ( cat_1, source_1, range_1, alpha_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( deduped_32_1, deduped_32_1 );
-    hoisted_24_1 := List( deduped_35_1, function ( i_2 )
+    deduped_1_1 := Concatenation( deduped_23_1, deduped_23_1 );
+    hoisted_15_1 := List( deduped_27_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_21_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
+            hoisted_2_2 := hoisted_12_1[deduped_3_2];
+            hoisted_1_2 := hoisted_14_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_12_1 := List( deduped_44_1, function ( a_2 )
+    hoisted_9_1 := Concatenation( deduped_32_1, deduped_32_1 );
+    deduped_10_1 := List( deduped_27_1, function ( j_2 )
+            return Product( hoisted_9_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_6_1 := List( deduped_37_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_9_1 := [ deduped_42_1, deduped_43_1 ];
-    deduped_8_1 := [ 0, 1 ];
-    deduped_3_1 := Concatenation( ListWithIdenticalEntries( deduped_40_1, 0 ), ListWithIdenticalEntries( deduped_41_1, 1 ) );
-    deduped_2_1 := List( deduped_44_1, function ( a_2 )
+    hoisted_3_1 := List( deduped_37_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_18_1 := Concatenation( List( deduped_39_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_2_1[(1 + i_2)]] )];
-          end ), List( deduped_39_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_12_1[(1 + i_2)]] )];
-          end ) );
-    deduped_19_1 := List( deduped_35_1, function ( j_2 )
-            return Product( hoisted_18_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_16_1 := Concatenation( List( deduped_39_1, function ( i_2 )
+    hoisted_7_1 := Concatenation( List( deduped_31_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_2_1[(1 + i_2)];
-              hoisted_2_2 := deduped_36_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_31_1, function ( i_3 )
+              deduped_3_2 := hoisted_3_1[1 + i_2];
+              hoisted_2_2 := deduped_28_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_28_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_22_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_39_1, function ( i_2 )
+          end ), List( deduped_31_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_12_1[(1 + i_2)];
-              hoisted_2_2 := deduped_36_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_36_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_31_1, function ( i_3 )
+              deduped_3_2 := hoisted_6_1[1 + i_2];
+              hoisted_2_2 := deduped_28_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_28_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_22_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_7_1 := [ 0, 1, 2, 3 ];
-    deduped_6_1 := [ 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 0, 0, 1 ];
-    deduped_4_1 := [ 0, 3 ];
-    hoisted_13_1 := Concatenation( List( deduped_39_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_2_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_38_1[SafeUniquePositionProperty( deduped_37_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_39_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_12_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_38_1[SafeUniquePositionProperty( deduped_37_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_17_1 := List( deduped_35_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( deduped_26_1, deduped_26_1 );
+    hoisted_8_1 := List( deduped_27_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_13_1[deduped_3_2];
-            hoisted_1_2 := hoisted_16_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_7_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_29_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_31_1, function ( x_2 )
+    deduped_20_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_22_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_27_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                            return hoisted_8_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_27_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
+                            return hoisted_15_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
                         end ) );
             end )[1 + AsList( alpha_1 )[(1 + CAP_JIT_INCOMPLETE_LOGIC( [ 0 .. (Length( Source( alpha_1 ) ) - 1) ][1] ))]] );
-    hoisted_28_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_29_1, deduped_33_1 ), Product( deduped_36_1{[ 1 + deduped_40_1 .. Sum( [ deduped_40_1, deduped_41_1 ]{[ 1, 2 ]} ) ]} ) ) );
-    hoisted_26_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_29_1, deduped_33_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( [ 0 .. deduped_40_1 - 1 ], function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_26_1, deduped_42_1 ^ i_2 ), deduped_42_1 );
-            end ), List( deduped_39_1, function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_28_1, deduped_43_1 ^ i_2 ), deduped_43_1 );
+    hoisted_19_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_20_1, deduped_24_1 ), Product( deduped_28_1{[ 1 + deduped_33_1 .. Sum( [ deduped_33_1, deduped_34_1 ]{[ 1, 2 ]} ) ]} ) ) );
+    hoisted_17_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_20_1, deduped_24_1 ) );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( [ 0 .. deduped_33_1 - 1 ], function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_17_1, deduped_35_1 ^ i_2 ), deduped_35_1 );
+            end ), List( deduped_31_1, function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_19_1, deduped_36_1 ^ i_2 ), deduped_36_1 );
             end ) ) );
 end
 ########
@@ -451,48 +326,51 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_12_1, hoisted_13_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, hoisted_21_1, hoisted_23_1, hoisted_24_1, deduped_27_1, hoisted_29_1, hoisted_30_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1;
-    deduped_54_1 := UnderlyingCategory( cat_1 );
-    deduped_53_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_52_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_51_1 := deduped_53_1[3];
-    deduped_50_1 := CreateCapCategoryObjectWithAttributes( deduped_54_1, IndexOfObject, 1 );
-    deduped_49_1 := CreateCapCategoryObjectWithAttributes( deduped_54_1, IndexOfObject, 0 );
-    deduped_48_1 := deduped_52_1[3];
-    deduped_47_1 := deduped_53_1[2];
-    deduped_46_1 := deduped_52_1[2];
-    deduped_45_1 := deduped_53_1[1];
-    deduped_44_1 := deduped_52_1[1];
-    deduped_43_1 := [ 0 .. deduped_46_1 - 1 ];
-    deduped_42_1 := [ List( deduped_51_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, hoisted_6_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, deduped_10_1, hoisted_12_1, hoisted_13_1, hoisted_14_1, hoisted_15_1, deduped_18_1, hoisted_20_1, hoisted_21_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1;
+    deduped_47_1 := UnderlyingCategory( cat_1 );
+    deduped_46_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_45_1 := DefiningTripleOfQuiverEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_44_1 := CreateCapCategoryObjectWithAttributes( deduped_47_1, IndexOfObject, 1 );
+    deduped_43_1 := CreateCapCategoryObjectWithAttributes( deduped_47_1, IndexOfObject, 0 );
+    deduped_42_1 := deduped_46_1[3];
+    deduped_41_1 := deduped_45_1[3];
+    deduped_40_1 := deduped_46_1[2];
+    deduped_39_1 := deduped_45_1[2];
+    deduped_38_1 := deduped_46_1[1];
+    deduped_37_1 := deduped_45_1[1];
+    deduped_36_1 := ListWithIdenticalEntries( deduped_39_1, deduped_38_1 );
+    deduped_35_1 := [ 0 .. deduped_39_1 - 1 ];
+    deduped_34_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_47_1, deduped_43_1, deduped_44_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_47_1, deduped_43_1, deduped_44_1, IndexOfMorphism, 2 ) ];
+    deduped_33_1 := [ List( deduped_42_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_51_1, function ( a_2 )
+            end ), List( deduped_42_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_41_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_54_1, deduped_49_1, deduped_50_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_54_1, deduped_49_1, deduped_50_1, IndexOfMorphism, 2 ) ];
-    deduped_40_1 := Concatenation( ListWithIdenticalEntries( deduped_44_1, deduped_45_1 ), ListWithIdenticalEntries( deduped_46_1, deduped_47_1 ) );
-    deduped_39_1 := [ 0 .. deduped_46_1 + deduped_46_1 - 1 ];
-    deduped_38_1 := Product( deduped_40_1 );
-    deduped_37_1 := ListWithIdenticalEntries( Length( deduped_43_1 ), deduped_38_1 );
-    deduped_36_1 := [ 0 .. deduped_38_1 - 1 ];
-    deduped_35_1 := List( deduped_43_1, function ( i_2 )
+    deduped_32_1 := Concatenation( ListWithIdenticalEntries( deduped_37_1, deduped_38_1 ), ListWithIdenticalEntries( deduped_39_1, deduped_40_1 ) );
+    deduped_31_1 := [ 0 .. deduped_39_1 + deduped_39_1 - 1 ];
+    deduped_30_1 := ListWithIdenticalEntries( deduped_39_1, [ 0 .. deduped_38_1 - 1 ] );
+    deduped_29_1 := Product( deduped_32_1 );
+    deduped_28_1 := ListWithIdenticalEntries( deduped_39_1, deduped_29_1 );
+    deduped_27_1 := [ 0 .. deduped_29_1 - 1 ];
+    hoisted_13_1 := [ deduped_37_1 .. deduped_37_1 + deduped_39_1 - 1 ];
+    deduped_26_1 := List( deduped_35_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_44_1);
-            hoisted_2_2 := deduped_40_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_40_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_36_1, function ( i_3 )
+            deduped_3_2 := hoisted_13_1[1 + i_2];
+            hoisted_2_2 := deduped_32_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_32_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_27_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_23_1 := Concatenation( deduped_35_1, deduped_35_1 );
-    hoisted_21_1 := Concatenation( ListWithIdenticalEntries( deduped_46_1, deduped_42_1[SafeUniquePositionProperty( deduped_41_1, function ( mor_2 )
+    hoisted_14_1 := Concatenation( deduped_26_1, deduped_26_1 );
+    hoisted_12_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, deduped_33_1[SafeUniquePositionProperty( deduped_34_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_46_1, deduped_42_1[SafeUniquePositionProperty( deduped_41_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_39_1, deduped_33_1[SafeUniquePositionProperty( deduped_34_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
@@ -500,144 +378,79 @@ function ( cat_1, arg2_1, arg3_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( deduped_37_1, deduped_37_1 );
-    hoisted_24_1 := List( deduped_39_1, function ( i_2 )
+    deduped_1_1 := Concatenation( deduped_28_1, deduped_28_1 );
+    hoisted_15_1 := List( deduped_31_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_21_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
+            hoisted_2_2 := hoisted_12_1[deduped_3_2];
+            hoisted_1_2 := hoisted_14_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_12_1 := List( deduped_48_1, function ( a_2 )
+    hoisted_9_1 := Concatenation( deduped_36_1, deduped_36_1 );
+    deduped_10_1 := List( deduped_31_1, function ( j_2 )
+            return Product( hoisted_9_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_6_1 := List( deduped_41_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_9_1 := [ deduped_45_1, deduped_47_1 ];
-    deduped_8_1 := [ 0, 1 ];
-    deduped_3_1 := Concatenation( ListWithIdenticalEntries( deduped_44_1, 0 ), ListWithIdenticalEntries( deduped_46_1, 1 ) );
-    deduped_2_1 := List( deduped_48_1, function ( a_2 )
+    hoisted_3_1 := List( deduped_41_1, function ( a_2 )
             return a_2[1];
         end );
-    hoisted_18_1 := Concatenation( List( deduped_43_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_2_1[(1 + i_2)]] )];
-          end ), List( deduped_43_1, function ( i_2 )
-              return deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_3_1[1 + deduped_12_1[(1 + i_2)]] )];
-          end ) );
-    deduped_19_1 := List( deduped_39_1, function ( j_2 )
-            return Product( hoisted_18_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_16_1 := Concatenation( List( deduped_43_1, function ( i_2 )
+    hoisted_7_1 := Concatenation( List( deduped_35_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_2_1[(1 + i_2)];
-              hoisted_2_2 := deduped_40_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_40_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_36_1, function ( i_3 )
+              deduped_3_2 := hoisted_3_1[1 + i_2];
+              hoisted_2_2 := deduped_32_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_32_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_27_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_43_1, function ( i_2 )
+          end ), List( deduped_35_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_12_1[(1 + i_2)];
-              hoisted_2_2 := deduped_40_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_40_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_36_1, function ( i_3 )
+              deduped_3_2 := hoisted_6_1[1 + i_2];
+              hoisted_2_2 := deduped_32_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_32_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_27_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_7_1 := [ 0, 1, 2, 3 ];
-    deduped_6_1 := [ 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 0, 0, 1 ];
-    deduped_4_1 := [ 0, 3 ];
-    hoisted_13_1 := Concatenation( List( deduped_43_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_2_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_42_1[SafeUniquePositionProperty( deduped_41_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_43_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_4_1[(1 + deduped_3_1[(1 + deduped_12_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_7_1[deduped_8_2];
-              deduped_6_2 := deduped_6_1[deduped_8_2];
-              deduped_5_2 := deduped_5_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_4_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_5_1[deduped_4_2] and deduped_6_2 = deduped_6_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_7_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_9_1[SafeUniquePosition( deduped_8_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_42_1[SafeUniquePositionProperty( deduped_41_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_17_1 := List( deduped_39_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( deduped_30_1, deduped_30_1 );
+    hoisted_8_1 := List( deduped_31_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_13_1[deduped_3_2];
-            hoisted_1_2 := hoisted_16_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_7_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_34_1 := Filtered( deduped_36_1, function ( x_2 )
+    deduped_25_1 := Filtered( deduped_27_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_31_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_17_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+                        return hoisted_8_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_31_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_19_1[deduped_1_3];
+                        return hoisted_15_1[deduped_1_3][deduped_1_2] * deduped_10_1[deduped_1_3];
                     end ) );
         end );
-    deduped_33_1 := Length( deduped_34_1 );
-    hoisted_30_1 := Product( deduped_40_1{[ 1 + deduped_44_1 .. Sum( [ deduped_44_1, deduped_46_1 ]{[ 1, 2 ]} ) ]} );
-    hoisted_29_1 := [ 0 .. deduped_44_1 - 1 ];
-    deduped_27_1 := Product( deduped_40_1{[ 1 .. deduped_44_1 ]} );
-    return List( [ 0 .. deduped_33_1 - 1 ], function ( i_2 )
+    deduped_24_1 := Length( deduped_25_1 );
+    hoisted_21_1 := Product( deduped_32_1{[ 1 + deduped_37_1 .. Sum( [ deduped_37_1, deduped_39_1 ]{[ 1, 2 ]} ) ]} );
+    hoisted_20_1 := [ 0 .. deduped_37_1 - 1 ];
+    deduped_18_1 := Product( deduped_32_1{[ 1 .. deduped_37_1 ]} );
+    return List( [ 0 .. deduped_24_1 - 1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_34_1[1 + REM_INT( i_2, deduped_33_1 )] );
-            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_27_1 ), hoisted_30_1 ) );
-            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_27_1 ) );
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( hoisted_29_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_1_2, deduped_45_1 ^ i_3 ), deduped_45_1 );
-                    end ), List( deduped_43_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_2_2, deduped_47_1 ^ i_3 ), deduped_47_1 );
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_25_1[1 + REM_INT( i_2, deduped_24_1 )] );
+            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_18_1 ), hoisted_21_1 ) );
+            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_18_1 ) );
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( hoisted_20_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_1_2, deduped_38_1 ^ i_3 ), deduped_38_1 );
+                    end ), List( deduped_35_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_2_2, deduped_40_1 ^ i_3 ), deduped_40_1 );
                     end ) ) );
         end );
 end

--- a/FunctorCategories/gap/precompiled_categories/FinReflexiveQuiversAsCCCPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinReflexiveQuiversAsCCCPrecompiled.gi
@@ -10,72 +10,73 @@ BindGlobal( "ADD_FUNCTIONS_FOR_FinReflexiveQuiversAsCCCPrecompiled", function ( 
         
 ########
 function ( cat_1, a_1, b_1 )
-    local deduped_1_1, deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, hoisted_19_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, deduped_25_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, hoisted_31_1, deduped_32_1, deduped_34_1, hoisted_35_1, deduped_36_1, hoisted_37_1, deduped_38_1, hoisted_39_1, hoisted_42_1, hoisted_43_1, hoisted_44_1, deduped_45_1, hoisted_47_1, hoisted_48_1, hoisted_49_1, deduped_50_1, hoisted_51_1, deduped_52_1, hoisted_54_1, hoisted_55_1, hoisted_56_1, hoisted_57_1, hoisted_58_1, hoisted_60_1, deduped_62_1, hoisted_63_1, deduped_64_1, deduped_66_1, deduped_67_1, hoisted_68_1, hoisted_69_1, deduped_70_1, hoisted_71_1, hoisted_72_1, deduped_73_1, deduped_74_1, deduped_75_1, deduped_76_1, deduped_77_1, deduped_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1, deduped_95_1, deduped_96_1, deduped_97_1, deduped_98_1, deduped_99_1, deduped_100_1, deduped_101_1, deduped_102_1, deduped_103_1, deduped_104_1, deduped_105_1, deduped_106_1, deduped_107_1, deduped_108_1, deduped_109_1, deduped_110_1, deduped_111_1, deduped_112_1, deduped_113_1, deduped_114_1, deduped_115_1, deduped_116_1, deduped_117_1, deduped_118_1, deduped_119_1, deduped_120_1, deduped_121_1, deduped_122_1, deduped_123_1;
-    deduped_123_1 := UnderlyingCategory( cat_1 );
-    deduped_122_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( b_1 );
-    deduped_121_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( a_1 );
-    deduped_120_1 := deduped_121_1[4];
-    deduped_119_1 := deduped_122_1[4];
-    deduped_118_1 := CreateCapCategoryObjectWithAttributes( deduped_123_1, IndexOfObject, 0 );
-    deduped_117_1 := CreateCapCategoryObjectWithAttributes( deduped_123_1, IndexOfObject, 1 );
-    deduped_116_1 := deduped_122_1[2];
-    deduped_115_1 := deduped_121_1[2];
-    deduped_114_1 := deduped_122_1[1];
-    deduped_113_1 := deduped_121_1[1];
-    deduped_112_1 := deduped_113_1 + deduped_115_1;
-    deduped_111_1 := 3 * deduped_115_1;
-    deduped_110_1 := 2 * deduped_113_1;
-    deduped_109_1 := [ 0 .. deduped_116_1 - 1 ];
-    deduped_108_1 := [ 0 .. deduped_114_1 - 1 ];
-    deduped_107_1 := [ 0 .. deduped_115_1 - 1 ];
-    deduped_106_1 := [ 0 .. deduped_113_1 - 1 ];
-    deduped_105_1 := [ deduped_122_1[3], List( deduped_119_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, deduped_4_1, deduped_5_1, deduped_9_1, deduped_10_1, hoisted_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, hoisted_20_1, hoisted_21_1, deduped_22_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, deduped_35_1, hoisted_36_1, deduped_37_1, hoisted_39_1, hoisted_40_1, hoisted_41_1, hoisted_42_1, hoisted_44_1, deduped_46_1, hoisted_47_1, deduped_48_1, deduped_50_1, hoisted_51_1, hoisted_52_1, deduped_53_1, hoisted_54_1, hoisted_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1, deduped_66_1, deduped_67_1, deduped_68_1, deduped_69_1, deduped_70_1, deduped_71_1, deduped_72_1, deduped_73_1, deduped_74_1, deduped_75_1, deduped_76_1, deduped_77_1, deduped_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1, deduped_95_1, deduped_96_1, deduped_97_1, deduped_98_1, deduped_99_1, deduped_100_1, deduped_101_1, deduped_102_1, deduped_103_1, deduped_104_1, deduped_105_1;
+    deduped_105_1 := UnderlyingCategory( cat_1 );
+    deduped_104_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( b_1 );
+    deduped_103_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( a_1 );
+    deduped_102_1 := CreateCapCategoryObjectWithAttributes( deduped_105_1, IndexOfObject, 0 );
+    deduped_101_1 := CreateCapCategoryObjectWithAttributes( deduped_105_1, IndexOfObject, 1 );
+    deduped_100_1 := deduped_104_1[4];
+    deduped_99_1 := deduped_103_1[4];
+    deduped_98_1 := deduped_104_1[2];
+    deduped_97_1 := deduped_103_1[2];
+    deduped_96_1 := deduped_104_1[1];
+    deduped_95_1 := deduped_103_1[1];
+    deduped_94_1 := ListWithIdenticalEntries( deduped_97_1, deduped_96_1 );
+    deduped_93_1 := deduped_95_1 + deduped_97_1;
+    deduped_92_1 := 3 * deduped_97_1;
+    deduped_91_1 := 2 * deduped_95_1;
+    deduped_90_1 := [ 0 .. deduped_97_1 - 1 ];
+    deduped_89_1 := [ 0 .. deduped_95_1 - 1 ];
+    deduped_88_1 := [ 0 .. deduped_96_1 - 1 ];
+    deduped_87_1 := [ 0 .. deduped_98_1 - 1 ];
+    deduped_86_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_105_1, deduped_101_1, deduped_102_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_105_1, deduped_102_1, deduped_101_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_105_1, deduped_102_1, deduped_101_1, IndexOfMorphism, 3 ) ];
+    deduped_85_1 := [ deduped_104_1[3], List( deduped_100_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_119_1, function ( a_2 )
+            end ), List( deduped_100_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_104_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_123_1, deduped_117_1, deduped_118_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_123_1, deduped_118_1, deduped_117_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_123_1, deduped_118_1, deduped_117_1, IndexOfMorphism, 3 ) ];
-    deduped_103_1 := deduped_112_1 - 1;
-    deduped_102_1 := deduped_110_1 + deduped_111_1;
-    deduped_101_1 := Concatenation( ListWithIdenticalEntries( deduped_113_1, deduped_114_1 ), ListWithIdenticalEntries( deduped_115_1, deduped_116_1 ) );
-    deduped_100_1 := [ 0 .. deduped_103_1 ];
-    deduped_99_1 := [ 0 .. deduped_111_1 - 1 ];
-    deduped_98_1 := [ 0 .. deduped_110_1 - 1 ];
-    deduped_97_1 := Length( deduped_107_1 );
-    deduped_96_1 := Length( deduped_106_1 );
-    deduped_95_1 := deduped_102_1 - 1;
-    deduped_94_1 := Concatenation( ListWithIdenticalEntries( deduped_110_1, deduped_114_1 ), ListWithIdenticalEntries( deduped_111_1, deduped_116_1 ) );
-    deduped_93_1 := Product( deduped_101_1 );
-    deduped_92_1 := [ 0 .. deduped_95_1 ];
-    deduped_91_1 := [ 0 .. Sum( [ deduped_113_1, deduped_115_1, deduped_115_1 ] ) - 1 ];
-    deduped_90_1 := Length( deduped_99_1 );
-    deduped_89_1 := Length( deduped_98_1 );
-    deduped_88_1 := ListWithIdenticalEntries( deduped_97_1, deduped_93_1 );
-    deduped_87_1 := Product( deduped_94_1 );
-    deduped_86_1 := [ 0 .. Sum( [ deduped_110_1, deduped_111_1, deduped_111_1 ] ) - 1 ];
-    deduped_85_1 := [ 0 .. deduped_93_1 - 1 ];
-    deduped_84_1 := [ 0 .. deduped_96_1 + deduped_97_1 - 1 ];
-    deduped_83_1 := ListWithIdenticalEntries( deduped_90_1, deduped_87_1 );
-    deduped_82_1 := [ 0 .. deduped_87_1 - 1 ];
-    deduped_81_1 := List( deduped_99_1, function ( i_2 )
+    deduped_84_1 := ListWithIdenticalEntries( deduped_92_1, deduped_96_1 );
+    deduped_83_1 := deduped_91_1 + deduped_92_1;
+    deduped_82_1 := deduped_93_1 - 1;
+    deduped_81_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_96_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_98_1 ) );
+    deduped_80_1 := [ 0 .. deduped_82_1 ];
+    deduped_79_1 := [ 0 .. deduped_92_1 - 1 ];
+    deduped_78_1 := [ 0 .. deduped_91_1 - 1 ];
+    deduped_77_1 := ListWithIdenticalEntries( deduped_92_1, deduped_88_1 );
+    deduped_76_1 := ListWithIdenticalEntries( deduped_97_1, deduped_88_1 );
+    deduped_75_1 := deduped_83_1 - 1;
+    deduped_74_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_96_1 ), ListWithIdenticalEntries( deduped_92_1, deduped_98_1 ) );
+    deduped_73_1 := Product( deduped_81_1 );
+    deduped_72_1 := [ 0 .. deduped_75_1 ];
+    deduped_71_1 := [ 0 .. Sum( [ deduped_95_1, deduped_97_1, deduped_97_1 ] ) - 1 ];
+    deduped_70_1 := ListWithIdenticalEntries( deduped_97_1, deduped_73_1 );
+    deduped_69_1 := Product( deduped_74_1 );
+    deduped_68_1 := [ 0 .. Sum( [ deduped_91_1, deduped_92_1, deduped_92_1 ] ) - 1 ];
+    deduped_67_1 := [ 0 .. deduped_73_1 - 1 ];
+    deduped_63_1 := [ 0 .. deduped_69_1 - 1 ];
+    deduped_22_1 := [ deduped_91_1 .. deduped_75_1 ];
+    deduped_66_1 := List( deduped_79_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_110_1);
-            hoisted_2_2 := deduped_94_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_82_1, function ( i_3 )
+            deduped_3_2 := deduped_22_1[1 + i_2];
+            hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_63_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    deduped_80_1 := List( deduped_107_1, function ( i_2 )
+    deduped_5_1 := [ deduped_95_1 .. deduped_82_1 ];
+    deduped_65_1 := List( deduped_90_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_113_1);
-            hoisted_2_2 := deduped_101_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_85_1, function ( i_3 )
+            deduped_3_2 := deduped_5_1[1 + i_2];
+            hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_67_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    deduped_79_1 := deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_2 )
+    deduped_64_1 := ListWithIdenticalEntries( deduped_92_1, deduped_69_1 );
+    deduped_62_1 := deduped_85_1[SafeUniquePositionProperty( deduped_86_1, function ( mor_2 )
              if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                  return IndexOfMorphism( mor_2 ) = 3;
              else
@@ -83,7 +84,7 @@ function ( cat_1, a_1, b_1 )
              fi;
              return;
          end )];
-    deduped_78_1 := deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_2 )
+    deduped_61_1 := deduped_85_1[SafeUniquePositionProperty( deduped_86_1, function ( mor_2 )
              if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                  return IndexOfMorphism( mor_2 ) = 2;
              else
@@ -91,7 +92,7 @@ function ( cat_1, a_1, b_1 )
              fi;
              return;
          end )];
-    deduped_77_1 := deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_2 )
+    deduped_60_1 := deduped_85_1[SafeUniquePositionProperty( deduped_86_1, function ( mor_2 )
              if IndexOfObject( Source( mor_2 ) ) = 1 and IndexOfObject( Range( mor_2 ) ) = 0 then
                  return IndexOfMorphism( mor_2 ) = 1;
              else
@@ -99,515 +100,308 @@ function ( cat_1, a_1, b_1 )
              fi;
              return;
          end )];
-    hoisted_48_1 := Concatenation( List( deduped_98_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + i_2;
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
+    hoisted_33_1 := Concatenation( List( deduped_78_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2;
+              hoisted_2_2 := deduped_74_1[1 + i_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. i_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), deduped_81_1, deduped_81_1 );
-    hoisted_47_1 := Concatenation( ListWithIdenticalEntries( deduped_110_1, deduped_77_1 ), ListWithIdenticalEntries( deduped_111_1, deduped_78_1 ), ListWithIdenticalEntries( deduped_111_1, deduped_79_1 ) );
-    deduped_30_1 := Concatenation( ListWithIdenticalEntries( deduped_89_1, deduped_87_1 ), deduped_83_1, deduped_83_1 );
-    hoisted_49_1 := List( deduped_86_1, function ( i_2 )
+          end ), deduped_66_1, deduped_66_1 );
+    hoisted_32_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_60_1 ), ListWithIdenticalEntries( deduped_92_1, deduped_61_1 ), ListWithIdenticalEntries( deduped_92_1, deduped_62_1 ) );
+    deduped_19_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_69_1 ), deduped_64_1, deduped_64_1 );
+    hoisted_34_1 := List( deduped_68_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_47_1[deduped_3_2];
-            hoisted_1_2 := hoisted_48_1[deduped_3_2];
-            return List( [ 0 .. deduped_30_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_32_1[deduped_3_2];
+            hoisted_1_2 := hoisted_33_1[deduped_3_2];
+            return List( [ 0 .. deduped_19_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_37_1 := [ 1, 0, 1 ];
-    deduped_17_1 := List( deduped_120_1, function ( a_2 )
+    hoisted_29_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_98_1 ), deduped_84_1, deduped_84_1 );
+    deduped_30_1 := List( deduped_68_1, function ( j_2 )
+            return Product( hoisted_29_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_26_1 := [ 1, 0, 1 ];
+    hoisted_25_1 := [ 0, 0, 1 ];
+    hoisted_21_1 := [ 1, 2 ];
+    deduped_10_1 := List( deduped_99_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_38_1 := List( deduped_99_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( hoisted_37_1[1 + REM_INT( deduped_1_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_17_1[(1 + REM_INT( QUO_INT( deduped_1_2, 3 ), deduped_115_1 ))] ) * 2;
-        end );
-    hoisted_35_1 := [ 0, 0, 1 ];
-    deduped_15_1 := List( deduped_120_1, function ( a_2 )
+    deduped_9_1 := List( deduped_99_1, function ( a_2 )
             return a_2[1];
         end );
-    deduped_36_1 := List( deduped_99_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( hoisted_35_1[1 + REM_INT( deduped_1_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_15_1[(1 + REM_INT( QUO_INT( deduped_1_2, 3 ), deduped_115_1 ))] ) * 2;
-        end );
-    deduped_34_1 := Concatenation( ListWithIdenticalEntries( deduped_110_1, 0 ), ListWithIdenticalEntries( deduped_111_1, 1 ) );
-    hoisted_31_1 := [ 1, 2 ];
-    deduped_3_1 := deduped_121_1[3];
-    deduped_32_1 := List( deduped_98_1, function ( i_2 )
-            local deduped_1_2;
-            deduped_1_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( hoisted_31_1[1 + REM_INT( deduped_1_2, 2 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_3_1[(1 + REM_INT( QUO_INT( deduped_1_2, 2 ), deduped_113_1 ))] ) * 3;
-        end );
-    deduped_11_1 := [ deduped_114_1, deduped_116_1 ];
-    deduped_10_1 := [ 0, 1 ];
-    hoisted_44_1 := Concatenation( List( deduped_98_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_34_1[1 + (deduped_32_1[1 + i_2] + deduped_110_1)] )];
-          end ), List( deduped_99_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_34_1[1 + deduped_36_1[(1 + i_2)]] )];
-          end ), List( deduped_99_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_34_1[1 + deduped_38_1[(1 + i_2)]] )];
-          end ) );
-    deduped_45_1 := List( deduped_86_1, function ( j_2 )
-            return Product( hoisted_44_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_42_1 := Concatenation( List( deduped_98_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + (deduped_32_1[1 + i_2] + deduped_110_1);
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_99_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_36_1[(1 + i_2)];
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_99_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_38_1[(1 + i_2)];
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ) );
-    deduped_9_1 := [ 0, 1, 2, 3, 4, 5, 6 ];
-    deduped_8_1 := [ 0, 0, 1, 1, 1, 1, 1 ];
-    deduped_7_1 := [ 0, 1, 0, 0, 1, 1, 1 ];
-    deduped_6_1 := [ 0, 4 ];
-    hoisted_39_1 := Concatenation( List( deduped_98_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_34_1[(1 + (deduped_32_1[1 + i_2] + deduped_110_1))])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_99_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_34_1[(1 + deduped_36_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_99_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_34_1[(1 + deduped_38_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_43_1 := List( deduped_86_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_39_1[deduped_3_2];
-            hoisted_1_2 := hoisted_42_1[deduped_3_2];
-            return List( [ 0 .. deduped_30_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_76_1 := Filtered( deduped_82_1, function ( x_2 )
-            local deduped_1_2;
-            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_86_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_43_1[deduped_1_3][deduped_1_2] * deduped_45_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_86_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_49_1[deduped_1_3][deduped_1_2] * deduped_45_1[deduped_1_3];
-                    end ) );
-        end );
-    hoisted_28_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + i_2;
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), deduped_80_1, deduped_80_1 );
-    hoisted_27_1 := Concatenation( ListWithIdenticalEntries( deduped_113_1, deduped_77_1 ), ListWithIdenticalEntries( deduped_115_1, deduped_78_1 ), ListWithIdenticalEntries( deduped_115_1, deduped_79_1 ) );
-    deduped_1_1 := Concatenation( ListWithIdenticalEntries( deduped_96_1, deduped_93_1 ), deduped_88_1, deduped_88_1 );
-    hoisted_29_1 := List( deduped_91_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_27_1[deduped_3_2];
-            hoisted_1_2 := hoisted_28_1[deduped_3_2];
-            return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_18_1 := List( deduped_107_1, function ( i_2 )
-            return deduped_17_1[1 + REM_INT( i_2, deduped_115_1 )];
-        end );
-    deduped_16_1 := List( deduped_107_1, function ( i_2 )
-            return deduped_15_1[1 + REM_INT( i_2, deduped_115_1 )];
-        end );
-    deduped_5_1 := Concatenation( ListWithIdenticalEntries( deduped_113_1, 0 ), ListWithIdenticalEntries( deduped_115_1, 1 ) );
-    deduped_4_1 := List( deduped_106_1, function ( i_2 )
-            return deduped_3_1[1 + REM_INT( i_2, deduped_113_1 )];
-        end );
-    hoisted_24_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_1[1 + (deduped_4_1[1 + i_2] + deduped_113_1)] )];
-          end ), List( deduped_107_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_1[1 + deduped_16_1[(1 + i_2)]] )];
-          end ), List( deduped_107_1, function ( i_2 )
-              return deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_1[1 + deduped_18_1[(1 + i_2)]] )];
-          end ) );
-    deduped_25_1 := List( deduped_91_1, function ( j_2 )
-            return Product( hoisted_24_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_22_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + (deduped_4_1[1 + i_2] + deduped_113_1);
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_107_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_16_1[(1 + i_2)];
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_107_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_18_1[(1 + i_2)];
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ) );
-    hoisted_19_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_5_1[(1 + (deduped_4_1[1 + i_2] + deduped_113_1))])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_107_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_5_1[(1 + deduped_16_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_107_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_6_1[(1 + deduped_5_1[(1 + deduped_18_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_9_1[deduped_8_2];
-              deduped_6_2 := deduped_8_1[deduped_8_2];
-              deduped_5_2 := deduped_7_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_6_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_7_1[deduped_4_2] and deduped_6_2 = deduped_8_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_9_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_11_1[SafeUniquePosition( deduped_10_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_105_1[SafeUniquePositionProperty( deduped_104_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_23_1 := List( deduped_91_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_19_1[deduped_3_2];
-            hoisted_1_2 := hoisted_22_1[deduped_3_2];
-            return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_75_1 := Filtered( deduped_85_1, function ( x_2 )
-            local deduped_1_2;
-            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_91_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_23_1[deduped_1_3][deduped_1_2] * deduped_25_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_91_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_29_1[deduped_1_3][deduped_1_2] * deduped_25_1[deduped_1_3];
-                    end ) );
-        end );
-    deduped_74_1 := Length( deduped_76_1 );
-    deduped_73_1 := Length( deduped_75_1 );
-    deduped_67_1 := [ deduped_110_1 .. deduped_95_1 ];
-    hoisted_71_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( (1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2) );
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_107_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_67_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( (2 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 3) ))];
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ) );
-    deduped_66_1 := Concatenation( ListWithIdenticalEntries( deduped_96_1, deduped_87_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_87_1 ) );
-    deduped_62_1 := Concatenation( ListWithIdenticalEntries( deduped_113_1, deduped_108_1 ), ListWithIdenticalEntries( deduped_115_1, deduped_109_1 ) );
-    hoisted_72_1 := List( deduped_84_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := deduped_62_1[deduped_3_2];
-            hoisted_1_2 := hoisted_71_1[deduped_3_2];
-            return List( [ 0 .. deduped_66_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_64_1 := List( deduped_100_1, function ( j_2 )
-            return Product( deduped_101_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_63_1 := List( [ 1 .. deduped_112_1 ], function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2;
-            hoisted_3_2 := deduped_62_1[i_2];
-            hoisted_2_2 := deduped_101_1[i_2];
-            hoisted_1_2 := Product( deduped_101_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_85_1, function ( i_3 )
-                    return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
-                end );
-        end );
-    deduped_70_1 := List( deduped_85_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_100_1, function ( j_3 )
-                    local deduped_1_3;
-                    deduped_1_3 := 1 + j_3;
-                    return hoisted_63_1[deduped_1_3][hoisted_1_2] * deduped_64_1[deduped_1_3];
-                end );
-        end );
-    hoisted_68_1 := Concatenation( List( deduped_106_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_107_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_67_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( (1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 3) ))];
-              hoisted_2_2 := deduped_94_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_94_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_82_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ) );
-    hoisted_69_1 := List( deduped_84_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := deduped_62_1[deduped_3_2];
-            hoisted_1_2 := hoisted_68_1[deduped_3_2];
-            return List( [ 0 .. deduped_66_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_52_1 := List( deduped_92_1, function ( j_2 )
-            return Product( deduped_94_1{[ 1 .. j_2 ]} );
-        end );
-    deduped_50_1 := Concatenation( ListWithIdenticalEntries( deduped_110_1, deduped_108_1 ), ListWithIdenticalEntries( deduped_111_1, deduped_109_1 ) );
-    hoisted_51_1 := List( [ 1 .. deduped_102_1 ], function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, hoisted_3_2;
-            hoisted_3_2 := deduped_50_1[i_2];
-            hoisted_2_2 := deduped_94_1[i_2];
-            hoisted_1_2 := Product( deduped_94_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_82_1, function ( i_3 )
-                    return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
-                end );
-        end );
-    hoisted_60_1 := List( deduped_82_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_92_1, function ( j_3 )
-                    local deduped_1_3;
-                    deduped_1_3 := 1 + j_3;
-                    return hoisted_51_1[deduped_1_3][hoisted_1_2] * deduped_52_1[deduped_1_3];
-                end );
-        end );
-    hoisted_56_1 := [ deduped_113_1 .. deduped_103_1 ];
-    hoisted_55_1 := [ 0, 0, 0 ];
-    hoisted_57_1 := Concatenation( List( deduped_98_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), 2 ), deduped_113_1 ) );
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
-                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
-                  end );
-          end ), List( deduped_99_1, function ( i_2 )
+    deduped_4_1 := deduped_103_1[3];
+    hoisted_27_1 := Concatenation( List( deduped_78_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2;
               deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-              deduped_3_2 := 1 + hoisted_56_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( (CAP_JIT_INCOMPLETE_LOGIC( hoisted_55_1[1 + REM_INT( deduped_4_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_4_2, 3 ), deduped_115_1 ) )) ))];
-              hoisted_2_2 := deduped_101_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_101_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_85_1, function ( i_3 )
+              deduped_3_2 := deduped_22_1[1 + CAP_JIT_INCOMPLETE_LOGIC( (CAP_JIT_INCOMPLETE_LOGIC( hoisted_21_1[1 + REM_INT( deduped_4_2, 2 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_4_1[(1 + REM_INT( QUO_INT( deduped_4_2, 2 ), deduped_95_1 ))] ) * 3) )];
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_79_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2;
+              deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( hoisted_25_1[1 + REM_INT( deduped_4_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_9_1[(1 + REM_INT( QUO_INT( deduped_4_2, 3 ), deduped_97_1 ))] ) * 2 );
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_79_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2;
+              deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( hoisted_26_1[1 + REM_INT( deduped_4_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( deduped_10_1[(1 + REM_INT( QUO_INT( deduped_4_2, 3 ), deduped_97_1 ))] ) * 2 );
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    hoisted_54_1 := Concatenation( ListWithIdenticalEntries( deduped_89_1, deduped_93_1 ), ListWithIdenticalEntries( deduped_90_1, deduped_93_1 ) );
-    hoisted_58_1 := List( [ 0 .. deduped_89_1 + deduped_90_1 - 1 ], function ( i_2 )
+    hoisted_20_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_87_1 ), deduped_77_1, deduped_77_1 );
+    hoisted_28_1 := List( deduped_68_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := deduped_50_1[deduped_3_2];
-            hoisted_1_2 := hoisted_57_1[deduped_3_2];
-            return List( [ 0 .. hoisted_54_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_20_1[deduped_3_2];
+            hoisted_1_2 := hoisted_27_1[deduped_3_2];
+            return List( [ 0 .. deduped_19_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets, NTuple( 4, deduped_73_1, deduped_74_1, List( [ 0 .. deduped_73_1 - 1 ], function ( x_2 )
+    deduped_59_1 := Filtered( deduped_63_1, function ( x_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_68_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_28_1[deduped_1_3][deduped_1_2] * deduped_30_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_68_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_34_1[deduped_1_3][deduped_1_2] * deduped_30_1[deduped_1_3];
+                    end ) );
+        end );
+    hoisted_17_1 := Concatenation( List( deduped_89_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2;
+              hoisted_2_2 := deduped_81_1[1 + i_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. i_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), deduped_65_1, deduped_65_1 );
+    hoisted_16_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_60_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_61_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_62_1 ) );
+    deduped_1_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_73_1 ), deduped_70_1, deduped_70_1 );
+    hoisted_18_1 := List( deduped_71_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_16_1[deduped_3_2];
+            hoisted_1_2 := hoisted_17_1[deduped_3_2];
+            return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_13_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_98_1 ), deduped_94_1, deduped_94_1 );
+    deduped_14_1 := List( deduped_71_1, function ( j_2 )
+            return Product( hoisted_13_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_11_1 := Concatenation( List( deduped_89_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := deduped_5_1[1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_4_1[(1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_95_1 ))] )];
+              hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_90_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_9_1[1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_97_1 )] );
+              hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_90_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_10_1[1 + REM_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), deduped_97_1 )] );
+              hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ) );
+    hoisted_2_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_87_1 ), deduped_76_1, deduped_76_1 );
+    hoisted_12_1 := List( deduped_71_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_11_1[deduped_3_2];
+            return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    deduped_58_1 := Filtered( deduped_67_1, function ( x_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_71_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_12_1[deduped_1_3][deduped_1_2] * deduped_14_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_71_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_18_1[deduped_1_3][deduped_1_2] * deduped_14_1[deduped_1_3];
+                    end ) );
+        end );
+    deduped_57_1 := Length( deduped_59_1 );
+    deduped_56_1 := Length( deduped_58_1 );
+    hoisted_54_1 := Concatenation( List( deduped_89_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( 1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_90_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := deduped_22_1[1 + CAP_JIT_INCOMPLETE_LOGIC( (2 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 3) )];
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ) );
+    deduped_50_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_69_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_69_1 ) );
+    deduped_46_1 := Concatenation( ListWithIdenticalEntries( deduped_95_1, deduped_88_1 ), ListWithIdenticalEntries( deduped_97_1, deduped_87_1 ) );
+    hoisted_55_1 := List( deduped_80_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := deduped_46_1[deduped_3_2];
+            hoisted_1_2 := hoisted_54_1[deduped_3_2];
+            return List( [ 0 .. deduped_50_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    deduped_48_1 := List( deduped_80_1, function ( j_2 )
+            return Product( deduped_81_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_47_1 := List( [ 1 .. deduped_93_1 ], function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, hoisted_3_2;
+            hoisted_3_2 := deduped_46_1[i_2];
+            hoisted_2_2 := deduped_81_1[i_2];
+            hoisted_1_2 := Product( deduped_81_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_67_1, function ( i_3 )
+                    return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
+                end );
+        end );
+    deduped_53_1 := List( deduped_67_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := 1 + i_2;
+            return Sum( deduped_80_1, function ( j_3 )
+                    local deduped_1_3;
+                    deduped_1_3 := 1 + j_3;
+                    return hoisted_47_1[deduped_1_3][hoisted_1_2] * deduped_48_1[deduped_1_3];
+                end );
+        end );
+    hoisted_51_1 := Concatenation( List( deduped_89_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 2 );
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_90_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := deduped_22_1[1 + CAP_JIT_INCOMPLETE_LOGIC( (1 + CAP_JIT_INCOMPLETE_LOGIC( i_2 ) * 3) )];
+              hoisted_2_2 := deduped_74_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_74_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_63_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ) );
+    hoisted_52_1 := List( deduped_80_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := deduped_46_1[deduped_3_2];
+            hoisted_1_2 := hoisted_51_1[deduped_3_2];
+            return List( [ 0 .. deduped_50_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    deduped_37_1 := List( deduped_72_1, function ( j_2 )
+            return Product( deduped_74_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_35_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_88_1 ), ListWithIdenticalEntries( deduped_92_1, deduped_87_1 ) );
+    hoisted_36_1 := List( [ 1 .. deduped_83_1 ], function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, hoisted_3_2;
+            hoisted_3_2 := deduped_35_1[i_2];
+            hoisted_2_2 := deduped_74_1[i_2];
+            hoisted_1_2 := Product( deduped_74_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_63_1, function ( i_3 )
+                    return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
+                end );
+        end );
+    hoisted_44_1 := List( deduped_63_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := 1 + i_2;
+            return Sum( deduped_72_1, function ( j_3 )
+                    local deduped_1_3;
+                    deduped_1_3 := 1 + j_3;
+                    return hoisted_36_1[deduped_1_3][hoisted_1_2] * deduped_37_1[deduped_1_3];
+                end );
+        end );
+    hoisted_40_1 := [ 0, 0, 0 ];
+    hoisted_41_1 := Concatenation( List( deduped_78_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( CAP_JIT_INCOMPLETE_LOGIC( i_2 ), 2 ), deduped_95_1 ) );
+              hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ), List( deduped_79_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2;
+              deduped_4_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
+              deduped_3_2 := deduped_5_1[1 + CAP_JIT_INCOMPLETE_LOGIC( (CAP_JIT_INCOMPLETE_LOGIC( hoisted_40_1[1 + REM_INT( deduped_4_2, 3 )] ) + CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_4_2, 3 ), deduped_97_1 ) )) )];
+              hoisted_2_2 := deduped_81_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_81_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_67_1, function ( i_3 )
+                      return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
+                  end );
+          end ) );
+    hoisted_39_1 := Concatenation( ListWithIdenticalEntries( deduped_91_1, deduped_73_1 ), ListWithIdenticalEntries( deduped_92_1, deduped_73_1 ) );
+    hoisted_42_1 := List( deduped_72_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := deduped_35_1[deduped_3_2];
+            hoisted_1_2 := hoisted_41_1[deduped_3_2];
+            return List( [ 0 .. hoisted_39_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    return CreateCapCategoryObjectWithAttributes( cat_1, DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets, NTuple( 4, deduped_56_1, deduped_57_1, List( [ 0 .. deduped_56_1 - 1 ], function ( x_2 )
                 local hoisted_1_2;
-                hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_75_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
-                return -1 + BigInt( SafePosition( deduped_76_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_60_1[(1 + Sum( deduped_92_1, function ( j_3 )
+                hoisted_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_58_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
+                return -1 + BigInt( SafePosition( deduped_59_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_44_1[(1 + Sum( deduped_72_1, function ( j_3 )
                                    local deduped_1_3;
                                    deduped_1_3 := (1 + j_3);
-                                   return hoisted_58_1[deduped_1_3][hoisted_1_2] * deduped_52_1[deduped_1_3];
+                                   return hoisted_42_1[deduped_1_3][hoisted_1_2] * deduped_37_1[deduped_1_3];
                                end ))] ) ) );
-            end ), List( [ 0 .. deduped_74_1 - 1 ], function ( x_2 )
+            end ), List( [ 0 .. deduped_57_1 - 1 ], function ( x_2 )
                 local deduped_1_2;
-                deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_76_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
-                return NTuple( 2, -1 + BigInt( SafePosition( deduped_75_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_70_1[(1 + Sum( deduped_100_1, function ( j_3 )
+                deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( deduped_59_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))] );
+                return NTuple( 2, -1 + BigInt( SafePosition( deduped_58_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_53_1[(1 + Sum( deduped_80_1, function ( j_3 )
                                      local deduped_1_3;
                                      deduped_1_3 := (1 + j_3);
-                                     return hoisted_69_1[deduped_1_3][deduped_1_2] * deduped_64_1[deduped_1_3];
-                                 end ))] ) ) ), -1 + BigInt( SafePosition( deduped_75_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_70_1[(1 + Sum( deduped_100_1, function ( j_3 )
+                                     return hoisted_52_1[deduped_1_3][deduped_1_2] * deduped_48_1[deduped_1_3];
+                                 end ))] ) ) ), -1 + BigInt( SafePosition( deduped_58_1, CAP_JIT_INCOMPLETE_LOGIC( deduped_53_1[(1 + Sum( deduped_80_1, function ( j_3 )
                                      local deduped_1_3;
                                      deduped_1_3 := (1 + j_3);
-                                     return hoisted_72_1[deduped_1_3][deduped_1_2] * deduped_64_1[deduped_1_3];
+                                     return hoisted_55_1[deduped_1_3][deduped_1_2] * deduped_48_1[deduped_1_3];
                                  end ))] ) ) ) );
             end ) ) );
 end

--- a/FunctorCategories/gap/precompiled_categories/FinReflexiveQuiversPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/FinReflexiveQuiversPrecompiled.gi
@@ -84,64 +84,66 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_13_1, deduped_14_1, hoisted_15_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1;
-    deduped_46_1 := UnderlyingCategory( cat_1 );
-    deduped_45_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_44_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_43_1 := deduped_44_1[4];
-    deduped_42_1 := deduped_45_1[4];
-    deduped_41_1 := CreateCapCategoryObjectWithAttributes( deduped_46_1, IndexOfObject, 0 );
-    deduped_40_1 := CreateCapCategoryObjectWithAttributes( deduped_46_1, IndexOfObject, 1 );
-    deduped_39_1 := deduped_45_1[2];
-    deduped_38_1 := deduped_44_1[2];
-    deduped_37_1 := deduped_45_1[1];
-    deduped_36_1 := deduped_44_1[1];
-    deduped_35_1 := [ 0 .. deduped_38_1 - 1 ];
-    deduped_34_1 := [ 0 .. deduped_36_1 - 1 ];
-    deduped_33_1 := [ deduped_45_1[3], List( deduped_42_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, deduped_12_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1;
+    deduped_39_1 := UnderlyingCategory( cat_1 );
+    deduped_38_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_37_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_36_1 := CreateCapCategoryObjectWithAttributes( deduped_39_1, IndexOfObject, 0 );
+    deduped_35_1 := CreateCapCategoryObjectWithAttributes( deduped_39_1, IndexOfObject, 1 );
+    deduped_34_1 := deduped_38_1[4];
+    deduped_33_1 := deduped_37_1[4];
+    deduped_32_1 := deduped_38_1[2];
+    deduped_31_1 := deduped_37_1[2];
+    deduped_30_1 := deduped_38_1[1];
+    deduped_29_1 := deduped_37_1[1];
+    deduped_28_1 := ListWithIdenticalEntries( deduped_31_1, deduped_30_1 );
+    deduped_27_1 := [ 0 .. deduped_31_1 - 1 ];
+    deduped_26_1 := [ 0 .. deduped_29_1 - 1 ];
+    deduped_25_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_39_1, deduped_35_1, deduped_36_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_39_1, deduped_36_1, deduped_35_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_39_1, deduped_36_1, deduped_35_1, IndexOfMorphism, 3 ) ];
+    deduped_24_1 := [ deduped_38_1[3], List( deduped_34_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_42_1, function ( a_2 )
+            end ), List( deduped_34_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_32_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_46_1, deduped_40_1, deduped_41_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_46_1, deduped_41_1, deduped_40_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_46_1, deduped_41_1, deduped_40_1, IndexOfMorphism, 3 ) ];
-    deduped_31_1 := Concatenation( ListWithIdenticalEntries( deduped_36_1, deduped_37_1 ), ListWithIdenticalEntries( deduped_38_1, deduped_39_1 ) );
-    deduped_30_1 := Product( deduped_31_1 );
-    deduped_29_1 := [ 0 .. Sum( [ deduped_36_1, deduped_38_1, deduped_38_1 ] ) - 1 ];
-    deduped_28_1 := ListWithIdenticalEntries( Length( deduped_35_1 ), deduped_30_1 );
-    deduped_27_1 := [ 0 .. deduped_30_1 - 1 ];
-    deduped_26_1 := List( deduped_35_1, function ( i_2 )
+    deduped_23_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, deduped_30_1 ), ListWithIdenticalEntries( deduped_31_1, deduped_32_1 ) );
+    deduped_22_1 := ListWithIdenticalEntries( deduped_31_1, [ 0 .. deduped_30_1 - 1 ] );
+    deduped_21_1 := Product( deduped_23_1 );
+    deduped_20_1 := [ 0 .. Sum( [ deduped_29_1, deduped_31_1, deduped_31_1 ] ) - 1 ];
+    deduped_19_1 := ListWithIdenticalEntries( deduped_31_1, deduped_21_1 );
+    deduped_18_1 := [ 0 .. deduped_21_1 - 1 ];
+    deduped_4_1 := [ deduped_29_1 .. deduped_29_1 + deduped_31_1 - 1 ];
+    deduped_17_1 := List( deduped_27_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_36_1);
-            hoisted_2_2 := deduped_31_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_31_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_27_1, function ( i_3 )
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            hoisted_2_2 := deduped_23_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_23_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_18_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_24_1 := Concatenation( List( deduped_34_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + i_2;
-              hoisted_2_2 := deduped_31_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_31_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_27_1, function ( i_3 )
+    hoisted_15_1 := Concatenation( List( deduped_26_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2;
+              hoisted_2_2 := deduped_23_1[1 + i_2];
+              hoisted_1_2 := Product( deduped_23_1{[ 1 .. i_2 ]} );
+              return List( deduped_18_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), deduped_26_1, deduped_26_1 );
-    hoisted_23_1 := Concatenation( ListWithIdenticalEntries( deduped_36_1, deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_2 )
+          end ), deduped_17_1, deduped_17_1 );
+    hoisted_14_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, deduped_24_1[SafeUniquePositionProperty( deduped_25_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 1 and IndexOfObject( Range( mor_2 ) ) = 0 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_38_1, deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_31_1, deduped_24_1[SafeUniquePositionProperty( deduped_25_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_38_1, deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_31_1, deduped_24_1[SafeUniquePositionProperty( deduped_25_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 3;
                  else
@@ -149,167 +151,73 @@ function ( cat_1, arg2_1, arg3_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( ListWithIdenticalEntries( Length( deduped_34_1 ), deduped_30_1 ), deduped_28_1, deduped_28_1 );
-    hoisted_25_1 := List( deduped_29_1, function ( i_2 )
+    deduped_1_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, deduped_21_1 ), deduped_19_1, deduped_19_1 );
+    hoisted_16_1 := List( deduped_20_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_23_1[deduped_3_2];
-            hoisted_1_2 := hoisted_24_1[deduped_3_2];
+            hoisted_2_2 := hoisted_14_1[deduped_3_2];
+            hoisted_1_2 := hoisted_15_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_14_1 := List( deduped_43_1, function ( a_2 )
+    hoisted_11_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, deduped_32_1 ), deduped_28_1, deduped_28_1 );
+    deduped_12_1 := List( deduped_20_1, function ( j_2 )
+            return Product( hoisted_11_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_8_1 := List( deduped_33_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_13_1 := List( deduped_43_1, function ( a_2 )
+    hoisted_7_1 := List( deduped_33_1, function ( a_2 )
             return a_2[1];
         end );
-    deduped_10_1 := [ deduped_37_1, deduped_39_1 ];
-    deduped_9_1 := [ 0, 1 ];
-    deduped_4_1 := Concatenation( ListWithIdenticalEntries( deduped_36_1, 0 ), ListWithIdenticalEntries( deduped_38_1, 1 ) );
-    deduped_2_1 := deduped_44_1[3];
-    hoisted_20_1 := Concatenation( List( deduped_34_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + (deduped_2_1[1 + i_2] + deduped_36_1)] )];
-          end ), List( deduped_35_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_13_1[(1 + i_2)]] )];
-          end ), List( deduped_35_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_14_1[(1 + i_2)]] )];
-          end ) );
-    deduped_21_1 := List( deduped_29_1, function ( j_2 )
-            return Product( hoisted_20_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_18_1 := Concatenation( List( deduped_34_1, function ( i_2 )
+    hoisted_3_1 := deduped_37_1[3];
+    hoisted_9_1 := Concatenation( List( deduped_26_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + (deduped_2_1[1 + i_2] + deduped_36_1);
-              hoisted_2_2 := deduped_31_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_31_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_27_1, function ( i_3 )
+              deduped_3_2 := deduped_4_1[1 + hoisted_3_1[(1 + i_2)]];
+              hoisted_2_2 := deduped_23_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_23_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_18_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_35_1, function ( i_2 )
+          end ), List( deduped_27_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_13_1[(1 + i_2)];
-              hoisted_2_2 := deduped_31_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_31_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_27_1, function ( i_3 )
+              deduped_3_2 := hoisted_7_1[1 + i_2];
+              hoisted_2_2 := deduped_23_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_23_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_18_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_35_1, function ( i_2 )
+          end ), List( deduped_27_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_14_1[(1 + i_2)];
-              hoisted_2_2 := deduped_31_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_31_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_27_1, function ( i_3 )
+              deduped_3_2 := hoisted_8_1[1 + i_2];
+              hoisted_2_2 := deduped_23_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_23_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_18_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_8_1 := [ 0, 1, 2, 3, 4, 5, 6 ];
-    deduped_7_1 := [ 0, 0, 1, 1, 1, 1, 1 ];
-    deduped_6_1 := [ 0, 1, 0, 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 4 ];
-    hoisted_15_1 := Concatenation( List( deduped_34_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + (deduped_2_1[1 + i_2] + deduped_36_1))])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_35_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_13_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_35_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_14_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_33_1[SafeUniquePositionProperty( deduped_32_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_19_1 := List( deduped_29_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( ListWithIdenticalEntries( deduped_29_1, [ 0 .. deduped_32_1 - 1 ] ), deduped_22_1, deduped_22_1 );
+    hoisted_10_1 := List( deduped_20_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_15_1[deduped_3_2];
-            hoisted_1_2 := hoisted_18_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_9_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_27_1, function ( x_2 )
+    return CreateCapCategoryObjectWithAttributes( RangeCategoryOfHomomorphismStructure( cat_1 ), Length, Length( Filtered( deduped_18_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_20_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_19_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_29_1, function ( j_3 )
+                            return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_20_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_25_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
+                            return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
                         end ) );
             end ) ) );
 end
@@ -322,65 +230,67 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_13_1, deduped_14_1, hoisted_15_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_27_1, hoisted_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1;
-    deduped_52_1 := UnderlyingCategory( cat_1 );
-    deduped_51_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( range_1 );
-    deduped_50_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( source_1 );
-    deduped_49_1 := deduped_50_1[4];
-    deduped_48_1 := deduped_51_1[4];
-    deduped_47_1 := CreateCapCategoryObjectWithAttributes( deduped_52_1, IndexOfObject, 0 );
-    deduped_46_1 := CreateCapCategoryObjectWithAttributes( deduped_52_1, IndexOfObject, 1 );
-    deduped_45_1 := deduped_51_1[2];
-    deduped_44_1 := deduped_51_1[1];
-    deduped_43_1 := deduped_50_1[2];
-    deduped_42_1 := deduped_50_1[1];
-    deduped_41_1 := [ 0 .. deduped_43_1 - 1 ];
-    deduped_40_1 := [ 0 .. deduped_42_1 - 1 ];
-    deduped_39_1 := [ deduped_51_1[3], List( deduped_48_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, deduped_12_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, hoisted_18_1, hoisted_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1;
+    deduped_45_1 := UnderlyingCategory( cat_1 );
+    deduped_44_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( range_1 );
+    deduped_43_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( source_1 );
+    deduped_42_1 := CreateCapCategoryObjectWithAttributes( deduped_45_1, IndexOfObject, 0 );
+    deduped_41_1 := CreateCapCategoryObjectWithAttributes( deduped_45_1, IndexOfObject, 1 );
+    deduped_40_1 := deduped_44_1[4];
+    deduped_39_1 := deduped_43_1[4];
+    deduped_38_1 := deduped_44_1[2];
+    deduped_37_1 := deduped_44_1[1];
+    deduped_36_1 := deduped_43_1[2];
+    deduped_35_1 := deduped_43_1[1];
+    deduped_34_1 := ListWithIdenticalEntries( deduped_36_1, deduped_37_1 );
+    deduped_33_1 := [ 0 .. deduped_36_1 - 1 ];
+    deduped_32_1 := [ 0 .. deduped_35_1 - 1 ];
+    deduped_31_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_45_1, deduped_41_1, deduped_42_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_45_1, deduped_42_1, deduped_41_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_45_1, deduped_42_1, deduped_41_1, IndexOfMorphism, 3 ) ];
+    deduped_30_1 := [ deduped_44_1[3], List( deduped_40_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_48_1, function ( a_2 )
+            end ), List( deduped_40_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_38_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_52_1, deduped_46_1, deduped_47_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_52_1, deduped_47_1, deduped_46_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_52_1, deduped_47_1, deduped_46_1, IndexOfMorphism, 3 ) ];
-    deduped_37_1 := Concatenation( ListWithIdenticalEntries( deduped_42_1, deduped_44_1 ), ListWithIdenticalEntries( deduped_43_1, deduped_45_1 ) );
-    deduped_36_1 := Product( deduped_37_1 );
-    deduped_35_1 := [ 0 .. Sum( [ deduped_42_1, deduped_43_1, deduped_43_1 ] ) - 1 ];
-    deduped_34_1 := Product( deduped_37_1{[ 1 .. deduped_42_1 ]} );
-    deduped_33_1 := ListWithIdenticalEntries( Length( deduped_41_1 ), deduped_36_1 );
-    deduped_32_1 := [ 0 .. deduped_36_1 - 1 ];
-    deduped_31_1 := List( deduped_41_1, function ( i_2 )
+    deduped_29_1 := Concatenation( ListWithIdenticalEntries( deduped_35_1, deduped_37_1 ), ListWithIdenticalEntries( deduped_36_1, deduped_38_1 ) );
+    deduped_28_1 := ListWithIdenticalEntries( deduped_36_1, [ 0 .. deduped_37_1 - 1 ] );
+    deduped_27_1 := Product( deduped_29_1 );
+    deduped_26_1 := [ 0 .. Sum( [ deduped_35_1, deduped_36_1, deduped_36_1 ] ) - 1 ];
+    deduped_25_1 := Product( deduped_29_1{[ 1 .. deduped_35_1 ]} );
+    deduped_24_1 := ListWithIdenticalEntries( deduped_36_1, deduped_27_1 );
+    deduped_23_1 := [ 0 .. deduped_27_1 - 1 ];
+    deduped_4_1 := [ deduped_35_1 .. deduped_35_1 + deduped_36_1 - 1 ];
+    deduped_22_1 := List( deduped_33_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_42_1);
-            hoisted_2_2 := deduped_37_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_32_1, function ( i_3 )
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            hoisted_2_2 := deduped_29_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_29_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_23_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_24_1 := Concatenation( List( deduped_40_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + i_2;
-              hoisted_2_2 := deduped_37_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_32_1, function ( i_3 )
+    hoisted_15_1 := Concatenation( List( deduped_32_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2;
+              hoisted_2_2 := deduped_29_1[1 + i_2];
+              hoisted_1_2 := Product( deduped_29_1{[ 1 .. i_2 ]} );
+              return List( deduped_23_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), deduped_31_1, deduped_31_1 );
-    hoisted_23_1 := Concatenation( ListWithIdenticalEntries( deduped_42_1, deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_2 )
+          end ), deduped_22_1, deduped_22_1 );
+    hoisted_14_1 := Concatenation( ListWithIdenticalEntries( deduped_35_1, deduped_30_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 1 and IndexOfObject( Range( mor_2 ) ) = 0 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_43_1, deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_36_1, deduped_30_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_43_1, deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_36_1, deduped_30_1[SafeUniquePositionProperty( deduped_31_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 3;
                  else
@@ -388,175 +298,81 @@ function ( cat_1, source_1, range_1, alpha_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( ListWithIdenticalEntries( Length( deduped_40_1 ), deduped_36_1 ), deduped_33_1, deduped_33_1 );
-    hoisted_25_1 := List( deduped_35_1, function ( i_2 )
+    deduped_1_1 := Concatenation( ListWithIdenticalEntries( deduped_35_1, deduped_27_1 ), deduped_24_1, deduped_24_1 );
+    hoisted_16_1 := List( deduped_26_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_23_1[deduped_3_2];
-            hoisted_1_2 := hoisted_24_1[deduped_3_2];
+            hoisted_2_2 := hoisted_14_1[deduped_3_2];
+            hoisted_1_2 := hoisted_15_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_14_1 := List( deduped_49_1, function ( a_2 )
+    hoisted_11_1 := Concatenation( ListWithIdenticalEntries( deduped_35_1, deduped_38_1 ), deduped_34_1, deduped_34_1 );
+    deduped_12_1 := List( deduped_26_1, function ( j_2 )
+            return Product( hoisted_11_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_8_1 := List( deduped_39_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_13_1 := List( deduped_49_1, function ( a_2 )
+    hoisted_7_1 := List( deduped_39_1, function ( a_2 )
             return a_2[1];
         end );
-    deduped_10_1 := [ deduped_44_1, deduped_45_1 ];
-    deduped_9_1 := [ 0, 1 ];
-    deduped_4_1 := Concatenation( ListWithIdenticalEntries( deduped_42_1, 0 ), ListWithIdenticalEntries( deduped_43_1, 1 ) );
-    deduped_2_1 := deduped_50_1[3];
-    hoisted_20_1 := Concatenation( List( deduped_40_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + (deduped_2_1[1 + i_2] + deduped_42_1)] )];
-          end ), List( deduped_41_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_13_1[(1 + i_2)]] )];
-          end ), List( deduped_41_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_14_1[(1 + i_2)]] )];
-          end ) );
-    deduped_21_1 := List( deduped_35_1, function ( j_2 )
-            return Product( hoisted_20_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_18_1 := Concatenation( List( deduped_40_1, function ( i_2 )
+    hoisted_3_1 := deduped_43_1[3];
+    hoisted_9_1 := Concatenation( List( deduped_32_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + (deduped_2_1[1 + i_2] + deduped_42_1);
-              hoisted_2_2 := deduped_37_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_32_1, function ( i_3 )
+              deduped_3_2 := deduped_4_1[1 + hoisted_3_1[(1 + i_2)]];
+              hoisted_2_2 := deduped_29_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_29_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_23_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_41_1, function ( i_2 )
+          end ), List( deduped_33_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_13_1[(1 + i_2)];
-              hoisted_2_2 := deduped_37_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_32_1, function ( i_3 )
+              deduped_3_2 := hoisted_7_1[1 + i_2];
+              hoisted_2_2 := deduped_29_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_29_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_23_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_41_1, function ( i_2 )
+          end ), List( deduped_33_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_14_1[(1 + i_2)];
-              hoisted_2_2 := deduped_37_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_32_1, function ( i_3 )
+              deduped_3_2 := hoisted_8_1[1 + i_2];
+              hoisted_2_2 := deduped_29_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_29_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_23_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_8_1 := [ 0, 1, 2, 3, 4, 5, 6 ];
-    deduped_7_1 := [ 0, 0, 1, 1, 1, 1, 1 ];
-    deduped_6_1 := [ 0, 1, 0, 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 4 ];
-    hoisted_15_1 := Concatenation( List( deduped_40_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + (deduped_2_1[1 + i_2] + deduped_42_1))])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_41_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_13_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_41_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_14_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_39_1[SafeUniquePositionProperty( deduped_38_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_19_1 := List( deduped_35_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( ListWithIdenticalEntries( deduped_35_1, [ 0 .. deduped_38_1 - 1 ] ), deduped_28_1, deduped_28_1 );
+    hoisted_10_1 := List( deduped_26_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_15_1[deduped_3_2];
-            hoisted_1_2 := hoisted_18_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_9_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_30_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_32_1, function ( x_2 )
+    deduped_21_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_23_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_26_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_19_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                            return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_26_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_25_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
+                            return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
                         end ) );
             end )[1 + AsList( alpha_1 )[(1 + CAP_JIT_INCOMPLETE_LOGIC( [ 0 .. (Length( Source( alpha_1 ) ) - 1) ][1] ))]] );
-    hoisted_29_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_30_1, deduped_34_1 ), Product( deduped_37_1{[ 1 + deduped_42_1 .. Sum( [ deduped_42_1, deduped_43_1 ]{[ 1, 2 ]} ) ]} ) ) );
-    hoisted_27_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_30_1, deduped_34_1 ) );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfReflexiveQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( deduped_40_1, function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_27_1, deduped_44_1 ^ i_2 ), deduped_44_1 );
-            end ), List( deduped_41_1, function ( i_2 )
-                return REM_INT( QUO_INT( hoisted_29_1, deduped_45_1 ^ i_2 ), deduped_45_1 );
+    hoisted_20_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_21_1, deduped_25_1 ), Product( deduped_29_1{[ 1 + deduped_35_1 .. Sum( [ deduped_35_1, deduped_36_1 ]{[ 1, 2 ]} ) ]} ) ) );
+    hoisted_18_1 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_21_1, deduped_25_1 ) );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, DefiningPairOfReflexiveQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( deduped_32_1, function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_18_1, deduped_37_1 ^ i_2 ), deduped_37_1 );
+            end ), List( deduped_33_1, function ( i_2 )
+                return REM_INT( QUO_INT( hoisted_20_1, deduped_38_1 ^ i_2 ), deduped_38_1 );
             end ) ) );
 end
 ########
@@ -568,64 +384,66 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_13_1, deduped_14_1, hoisted_15_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, deduped_28_1, hoisted_31_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1;
-    deduped_56_1 := UnderlyingCategory( cat_1 );
-    deduped_55_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg3_1 );
-    deduped_54_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg2_1 );
-    deduped_53_1 := deduped_54_1[4];
-    deduped_52_1 := deduped_55_1[4];
-    deduped_51_1 := CreateCapCategoryObjectWithAttributes( deduped_56_1, IndexOfObject, 0 );
-    deduped_50_1 := CreateCapCategoryObjectWithAttributes( deduped_56_1, IndexOfObject, 1 );
-    deduped_49_1 := deduped_55_1[2];
-    deduped_48_1 := deduped_54_1[2];
-    deduped_47_1 := deduped_55_1[1];
-    deduped_46_1 := deduped_54_1[1];
-    deduped_45_1 := [ 0 .. deduped_48_1 - 1 ];
-    deduped_44_1 := [ 0 .. deduped_46_1 - 1 ];
-    deduped_43_1 := [ deduped_55_1[3], List( deduped_52_1, function ( a_2 )
+    local deduped_1_1, hoisted_2_1, hoisted_3_1, deduped_4_1, hoisted_7_1, hoisted_8_1, hoisted_9_1, hoisted_10_1, hoisted_11_1, deduped_12_1, hoisted_14_1, hoisted_15_1, hoisted_16_1, deduped_19_1, hoisted_22_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, deduped_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1;
+    deduped_49_1 := UnderlyingCategory( cat_1 );
+    deduped_48_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg3_1 );
+    deduped_47_1 := DefiningQuadrupleOfReflexiveQuiverEnrichedOverSkeletalFinSets( arg2_1 );
+    deduped_46_1 := CreateCapCategoryObjectWithAttributes( deduped_49_1, IndexOfObject, 0 );
+    deduped_45_1 := CreateCapCategoryObjectWithAttributes( deduped_49_1, IndexOfObject, 1 );
+    deduped_44_1 := deduped_48_1[4];
+    deduped_43_1 := deduped_47_1[4];
+    deduped_42_1 := deduped_48_1[2];
+    deduped_41_1 := deduped_47_1[2];
+    deduped_40_1 := deduped_48_1[1];
+    deduped_39_1 := deduped_47_1[1];
+    deduped_38_1 := ListWithIdenticalEntries( deduped_41_1, deduped_40_1 );
+    deduped_37_1 := [ 0 .. deduped_41_1 - 1 ];
+    deduped_36_1 := [ 0 .. deduped_39_1 - 1 ];
+    deduped_35_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_49_1, deduped_45_1, deduped_46_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_49_1, deduped_46_1, deduped_45_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_49_1, deduped_46_1, deduped_45_1, IndexOfMorphism, 3 ) ];
+    deduped_34_1 := [ deduped_48_1[3], List( deduped_44_1, function ( a_2 )
                 return a_2[1];
-            end ), List( deduped_52_1, function ( a_2 )
+            end ), List( deduped_44_1, function ( a_2 )
                 return a_2[2];
             end ) ];
-    deduped_42_1 := [ CreateCapCategoryMorphismWithAttributes( deduped_56_1, deduped_50_1, deduped_51_1, IndexOfMorphism, 1 ), CreateCapCategoryMorphismWithAttributes( deduped_56_1, deduped_51_1, deduped_50_1, IndexOfMorphism, 2 ), CreateCapCategoryMorphismWithAttributes( deduped_56_1, deduped_51_1, deduped_50_1, IndexOfMorphism, 3 ) ];
-    deduped_41_1 := Concatenation( ListWithIdenticalEntries( deduped_46_1, deduped_47_1 ), ListWithIdenticalEntries( deduped_48_1, deduped_49_1 ) );
-    deduped_40_1 := Product( deduped_41_1 );
-    deduped_39_1 := [ 0 .. Sum( [ deduped_46_1, deduped_48_1, deduped_48_1 ] ) - 1 ];
-    deduped_38_1 := ListWithIdenticalEntries( Length( deduped_45_1 ), deduped_40_1 );
-    deduped_37_1 := [ 0 .. deduped_40_1 - 1 ];
-    deduped_36_1 := List( deduped_45_1, function ( i_2 )
+    deduped_33_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, deduped_40_1 ), ListWithIdenticalEntries( deduped_41_1, deduped_42_1 ) );
+    deduped_32_1 := ListWithIdenticalEntries( deduped_41_1, [ 0 .. deduped_40_1 - 1 ] );
+    deduped_31_1 := Product( deduped_33_1 );
+    deduped_30_1 := [ 0 .. Sum( [ deduped_39_1, deduped_41_1, deduped_41_1 ] ) - 1 ];
+    deduped_29_1 := ListWithIdenticalEntries( deduped_41_1, deduped_31_1 );
+    deduped_28_1 := [ 0 .. deduped_31_1 - 1 ];
+    deduped_4_1 := [ deduped_39_1 .. deduped_39_1 + deduped_41_1 - 1 ];
+    deduped_27_1 := List( deduped_37_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + (i_2 + deduped_46_1);
-            hoisted_2_2 := deduped_41_1[deduped_3_2];
-            hoisted_1_2 := Product( deduped_41_1{[ 1 .. deduped_3_2 - 1 ]} );
-            return List( deduped_37_1, function ( i_3 )
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            hoisted_2_2 := deduped_33_1[1 + deduped_3_2];
+            hoisted_1_2 := Product( deduped_33_1{[ 1 .. deduped_3_2 ]} );
+            return List( deduped_28_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    hoisted_24_1 := Concatenation( List( deduped_44_1, function ( i_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + i_2;
-              hoisted_2_2 := deduped_41_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_41_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_37_1, function ( i_3 )
+    hoisted_15_1 := Concatenation( List( deduped_36_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2;
+              hoisted_2_2 := deduped_33_1[1 + i_2];
+              hoisted_1_2 := Product( deduped_33_1{[ 1 .. i_2 ]} );
+              return List( deduped_28_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), deduped_36_1, deduped_36_1 );
-    hoisted_23_1 := Concatenation( ListWithIdenticalEntries( deduped_46_1, deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_2 )
+          end ), deduped_27_1, deduped_27_1 );
+    hoisted_14_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, deduped_34_1[SafeUniquePositionProperty( deduped_35_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 1 and IndexOfObject( Range( mor_2 ) ) = 0 then
                      return IndexOfMorphism( mor_2 ) = 1;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_48_1, deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_41_1, deduped_34_1[SafeUniquePositionProperty( deduped_35_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 2;
                  else
                      return false;
                  fi;
                  return;
-             end )] ), ListWithIdenticalEntries( deduped_48_1, deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_2 )
+             end )] ), ListWithIdenticalEntries( deduped_41_1, deduped_34_1[SafeUniquePositionProperty( deduped_35_1, function ( mor_2 )
                  if IndexOfObject( Source( mor_2 ) ) = 0 and IndexOfObject( Range( mor_2 ) ) = 1 then
                      return IndexOfMorphism( mor_2 ) = 3;
                  else
@@ -633,181 +451,87 @@ function ( cat_1, arg2_1, arg3_1 )
                  fi;
                  return;
              end )] ) );
-    deduped_1_1 := Concatenation( ListWithIdenticalEntries( Length( deduped_44_1 ), deduped_40_1 ), deduped_38_1, deduped_38_1 );
-    hoisted_25_1 := List( deduped_39_1, function ( i_2 )
+    deduped_1_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, deduped_31_1 ), deduped_29_1, deduped_29_1 );
+    hoisted_16_1 := List( deduped_30_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_23_1[deduped_3_2];
-            hoisted_1_2 := hoisted_24_1[deduped_3_2];
+            hoisted_2_2 := hoisted_14_1[deduped_3_2];
+            hoisted_1_2 := hoisted_15_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_14_1 := List( deduped_53_1, function ( a_2 )
+    hoisted_11_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, deduped_42_1 ), deduped_38_1, deduped_38_1 );
+    deduped_12_1 := List( deduped_30_1, function ( j_2 )
+            return Product( hoisted_11_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_8_1 := List( deduped_43_1, function ( a_2 )
             return a_2[2];
         end );
-    deduped_13_1 := List( deduped_53_1, function ( a_2 )
+    hoisted_7_1 := List( deduped_43_1, function ( a_2 )
             return a_2[1];
         end );
-    deduped_10_1 := [ deduped_47_1, deduped_49_1 ];
-    deduped_9_1 := [ 0, 1 ];
-    deduped_4_1 := Concatenation( ListWithIdenticalEntries( deduped_46_1, 0 ), ListWithIdenticalEntries( deduped_48_1, 1 ) );
-    deduped_2_1 := deduped_54_1[3];
-    hoisted_20_1 := Concatenation( List( deduped_44_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + (deduped_2_1[1 + i_2] + deduped_46_1)] )];
-          end ), List( deduped_45_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_13_1[(1 + i_2)]] )];
-          end ), List( deduped_45_1, function ( i_2 )
-              return deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_4_1[1 + deduped_14_1[(1 + i_2)]] )];
-          end ) );
-    deduped_21_1 := List( deduped_39_1, function ( j_2 )
-            return Product( hoisted_20_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_18_1 := Concatenation( List( deduped_44_1, function ( i_2 )
+    hoisted_3_1 := deduped_47_1[3];
+    hoisted_9_1 := Concatenation( List( deduped_36_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + (deduped_2_1[1 + i_2] + deduped_46_1);
-              hoisted_2_2 := deduped_41_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_41_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_37_1, function ( i_3 )
+              deduped_3_2 := deduped_4_1[1 + hoisted_3_1[(1 + i_2)]];
+              hoisted_2_2 := deduped_33_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_33_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_28_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_45_1, function ( i_2 )
+          end ), List( deduped_37_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_13_1[(1 + i_2)];
-              hoisted_2_2 := deduped_41_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_41_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_37_1, function ( i_3 )
+              deduped_3_2 := hoisted_7_1[1 + i_2];
+              hoisted_2_2 := deduped_33_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_33_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_28_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
-          end ), List( deduped_45_1, function ( i_2 )
+          end ), List( deduped_37_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + deduped_14_1[(1 + i_2)];
-              hoisted_2_2 := deduped_41_1[deduped_3_2];
-              hoisted_1_2 := Product( deduped_41_1{[ 1 .. deduped_3_2 - 1 ]} );
-              return List( deduped_37_1, function ( i_3 )
+              deduped_3_2 := hoisted_8_1[1 + i_2];
+              hoisted_2_2 := deduped_33_1[1 + deduped_3_2];
+              hoisted_1_2 := Product( deduped_33_1{[ 1 .. deduped_3_2 ]} );
+              return List( deduped_28_1, function ( i_3 )
                       return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                   end );
           end ) );
-    deduped_8_1 := [ 0, 1, 2, 3, 4, 5, 6 ];
-    deduped_7_1 := [ 0, 0, 1, 1, 1, 1, 1 ];
-    deduped_6_1 := [ 0, 1, 0, 0, 1, 1, 1 ];
-    deduped_5_1 := [ 0, 4 ];
-    hoisted_15_1 := Concatenation( List( deduped_44_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + (deduped_2_1[1 + i_2] + deduped_46_1))])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_45_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_13_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ), List( deduped_45_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + deduped_5_1[(1 + deduped_4_1[(1 + deduped_14_1[(1 + i_2)])])];
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := deduped_7_1[deduped_8_2];
-              deduped_5_2 := deduped_6_1[deduped_8_2];
-              deduped_4_2 := 1 + deduped_5_1[(1 + deduped_5_2)];
-              if IdFunc( function (  )
-                          if deduped_5_2 = deduped_6_1[deduped_4_2] and deduped_6_2 = deduped_7_1[deduped_4_2] then
-                              return deduped_7_2 = deduped_8_1[deduped_4_2];
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return [ 0 .. deduped_10_1[SafeUniquePosition( deduped_9_1, deduped_5_2 )] - 1 ];
-              else
-                  return deduped_43_1[SafeUniquePositionProperty( deduped_42_1, function ( mor_3 )
-                           if IndexOfObject( Source( mor_3 ) ) = deduped_5_2 and IndexOfObject( Range( mor_3 ) ) = deduped_6_2 then
-                               return IndexOfMorphism( mor_3 ) = deduped_7_2;
-                           else
-                               return false;
-                           fi;
-                           return;
-                       end )];
-              fi;
-              return;
-          end ) );
-    hoisted_19_1 := List( deduped_39_1, function ( i_2 )
+    hoisted_2_1 := Concatenation( ListWithIdenticalEntries( deduped_39_1, [ 0 .. deduped_42_1 - 1 ] ), deduped_32_1, deduped_32_1 );
+    hoisted_10_1 := List( deduped_30_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_15_1[deduped_3_2];
-            hoisted_1_2 := hoisted_18_1[deduped_3_2];
+            hoisted_2_2 := hoisted_2_1[deduped_3_2];
+            hoisted_1_2 := hoisted_9_1[deduped_3_2];
             return List( [ 0 .. deduped_1_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_35_1 := Filtered( deduped_37_1, function ( x_2 )
+    deduped_26_1 := Filtered( deduped_28_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_30_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_19_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+                        return hoisted_10_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_30_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_25_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
+                        return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_12_1[deduped_1_3];
                     end ) );
         end );
-    deduped_34_1 := Length( deduped_35_1 );
-    hoisted_31_1 := Product( deduped_41_1{[ 1 + deduped_46_1 .. Sum( [ deduped_46_1, deduped_48_1 ]{[ 1, 2 ]} ) ]} );
-    deduped_28_1 := Product( deduped_41_1{[ 1 .. deduped_46_1 ]} );
-    return List( [ 0 .. deduped_34_1 - 1 ], function ( i_2 )
+    deduped_25_1 := Length( deduped_26_1 );
+    hoisted_22_1 := Product( deduped_33_1{[ 1 + deduped_39_1 .. Sum( [ deduped_39_1, deduped_41_1 ]{[ 1, 2 ]} ) ]} );
+    deduped_19_1 := Product( deduped_33_1{[ 1 .. deduped_39_1 ]} );
+    return List( [ 0 .. deduped_25_1 - 1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_35_1[1 + REM_INT( i_2, deduped_34_1 )] );
-            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_28_1 ), hoisted_31_1 ) );
-            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_28_1 ) );
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfReflexiveQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( deduped_44_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_1_2, deduped_47_1 ^ i_3 ), deduped_47_1 );
-                    end ), List( deduped_45_1, function ( i_3 )
-                        return REM_INT( QUO_INT( hoisted_2_2, deduped_49_1 ^ i_3 ), deduped_49_1 );
+            deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( deduped_26_1[1 + REM_INT( i_2, deduped_25_1 )] );
+            hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( deduped_3_2, deduped_19_1 ), hoisted_22_1 ) );
+            hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( deduped_3_2, deduped_19_1 ) );
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, DefiningPairOfReflexiveQuiverMorphismEnrichedOverSkeletalFinSets, NTuple( 2, List( deduped_36_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_1_2, deduped_40_1 ^ i_3 ), deduped_40_1 );
+                    end ), List( deduped_37_1, function ( i_3 )
+                        return REM_INT( QUO_INT( hoisted_2_2, deduped_42_1 ^ i_3 ), deduped_42_1 );
                     end ) ) );
         end );
 end

--- a/FunctorCategories/gap/precompiled_categories/PreSheavesOfAlgebroidFromDataTablesInCategoryOfRowsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/PreSheavesOfAlgebroidFromDataTablesInCategoryOfRowsPrecompiled.gi
@@ -449,8 +449,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -475,8 +475,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -843,8 +843,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_3_2 := SyzygiesOfRows( deduped_7_2 );
                 deduped_6_2 := UniqueRightDivide( UnionOfColumns( deduped_1_1, deduped_10_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CertainColumns( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
+                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} );
+                            return CertainColumns( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
                         end ) ), SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_5_1} )) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -896,8 +896,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_2_2 := SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_6_1} ) + (- UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_7_1} )) );
               deduped_4_2 := UniqueRightDivide( UnionOfColumns( deduped_3_1, hoisted_2_1[o_2], List( hoisted_8_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CertainColumns( hoisted_2_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CertainColumns( hoisted_2_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
                       end ) ), SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_11_1} ) + (- UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_12_1} )) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_13_1, deduped_14_1[o_2], CreateCapCategoryObjectWithAttributes( deduped_13_1, RankOfObject, NumberColumns( deduped_4_2 ) ), UnderlyingMatrix, deduped_4_2 );
           end ) );
@@ -1263,13 +1263,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} );
               deduped_3_2 := List( hoisted_4_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) ) * UnionOfColumns( HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_2_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_2_1 ), HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_2_1 ) );
                   end );
-              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_8_1, CAP_JIT_INCOMPLETE_LOGIC( Range( CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ) ) ), CreateCapCategoryObjectWithAttributes( deduped_8_1, RankOfObject, NumberColumns( deduped_2_2 ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -1905,13 +1905,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} );
               deduped_3_2 := List( hoisted_3_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return UnionOfRows( HomalgZeroMatrix( Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_1_3, deduped_1_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_1_1 ), HomalgZeroMatrix( Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_1_3, deduped_1_1 ) ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) );
                   end );
-              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_7_1, CreateCapCategoryObjectWithAttributes( deduped_7_1, RankOfObject, NumberRows( deduped_2_2 ) ), CAP_JIT_INCOMPLETE_LOGIC( Source( CAP_JIT_INCOMPLETE_LOGIC( hoisted_8_1[o_2] ) ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -2001,8 +2001,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_5_2 := SyzygiesOfColumns( deduped_7_2 );
                 deduped_6_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_5_1} )) ), UnionOfRows( deduped_1_1, deduped_11_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_13_2[i_3]) ] );
+                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} );
+                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_13_2[i_3]) ] );
                         end ) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -2054,8 +2054,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_3_2 := SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_9_1} ) + (- UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_10_1} )) );
               deduped_4_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_5_1} )) ), UnionOfRows( deduped_1_1, hoisted_6_1[o_2], List( hoisted_11_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] );
                       end ) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_12_1, CreateCapCategoryObjectWithAttributes( deduped_12_1, RankOfObject, NumberRows( deduped_4_2 ) ), deduped_14_1[o_2], UnderlyingMatrix, deduped_4_2 );
           end ) );

--- a/FunctorCategories/gap/precompiled_categories/PreSheavesOfAlgebroidWithRelationsInCategoryOfRowsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/PreSheavesOfAlgebroidWithRelationsInCategoryOfRowsPrecompiled.gi
@@ -448,8 +448,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -474,8 +474,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -837,8 +837,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_3_2 := SyzygiesOfRows( deduped_7_2 );
                 deduped_6_2 := UniqueRightDivide( UnionOfColumns( deduped_1_1, deduped_10_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CertainColumns( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
+                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} );
+                            return CertainColumns( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
                         end ) ), SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_5_1} )) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -889,8 +889,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_2_2 := SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_6_1} ) + (- UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_7_1} )) );
               deduped_4_2 := UniqueRightDivide( UnionOfColumns( deduped_3_1, hoisted_2_1[o_2], List( hoisted_8_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CertainColumns( hoisted_2_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CertainColumns( hoisted_2_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
                       end ) ), SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_11_1} ) + (- UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_12_1} )) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_15_1, deduped_14_1[o_2], CreateCapCategoryObjectWithAttributes( deduped_15_1, RankOfObject, NumberColumns( deduped_4_2 ) ), UnderlyingMatrix, deduped_4_2 );
           end ) );
@@ -1253,13 +1253,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} );
               deduped_3_2 := List( hoisted_4_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) ) * UnionOfColumns( HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_2_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_2_1 ), HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_2_1 ) );
                   end );
-              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CAP_JIT_INCOMPLETE_LOGIC( Range( CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ) ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_2_2 ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -1889,13 +1889,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} );
               deduped_3_2 := List( hoisted_3_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return UnionOfRows( HomalgZeroMatrix( Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_1_3, deduped_1_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_1_1 ), HomalgZeroMatrix( Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_1_3, deduped_1_1 ) ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) );
                   end );
-              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_2_2 ) ), CAP_JIT_INCOMPLETE_LOGIC( Source( CAP_JIT_INCOMPLETE_LOGIC( hoisted_8_1[o_2] ) ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -1984,8 +1984,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_5_2 := SyzygiesOfColumns( deduped_7_2 );
                 deduped_6_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_5_1} )) ), UnionOfRows( deduped_1_1, deduped_11_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_13_2[i_3]) ] );
+                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} );
+                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_13_2[i_3]) ] );
                         end ) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -2036,8 +2036,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_3_2 := SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_9_1} ) + (- UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_10_1} )) );
               deduped_4_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_5_1} )) ), UnionOfRows( deduped_1_1, hoisted_6_1[o_2], List( hoisted_11_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] );
                       end ) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_15_1, CreateCapCategoryObjectWithAttributes( deduped_15_1, RankOfObject, NumberRows( deduped_4_2 ) ), deduped_14_1[o_2], UnderlyingMatrix, deduped_4_2 );
           end ) );

--- a/FunctorCategories/gap/precompiled_categories/PreSheavesOfCategoryFromDataTablesInSkeletalFinSetsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/PreSheavesOfCategoryFromDataTablesInSkeletalFinSetsPrecompiled.gi
@@ -117,176 +117,137 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, hoisted_17_1, deduped_18_1, deduped_19_1, hoisted_20_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, deduped_26_1, hoisted_28_1, hoisted_29_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1;
-    deduped_49_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_48_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_47_1 := Source( cat_1 );
-    deduped_46_1 := IndicesOfGeneratingMorphisms( deduped_47_1 );
-    deduped_45_1 := deduped_48_1[2];
-    deduped_44_1 := DataTables( deduped_47_1 );
-    deduped_43_1 := DefiningTripleOfUnderlyingQuiver( deduped_47_1 );
-    deduped_42_1 := deduped_44_1[2];
-    deduped_41_1 := deduped_44_1[1];
-    deduped_40_1 := [ 0 .. deduped_43_1[2] - 1 ];
-    deduped_39_1 := [ 0 .. deduped_43_1[1] - 1 ];
-    deduped_38_1 := [ 0 .. deduped_41_1[2] - 1 ];
-    deduped_3_1 := List( deduped_49_1[1], Length );
-    deduped_2_1 := [ 0 .. deduped_41_1[1] - 1 ];
-    deduped_1_1 := List( deduped_48_1[1], Length );
-    deduped_37_1 := Concatenation( List( deduped_39_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], deduped_3_1[SafeUniquePosition( deduped_2_1, i_2 )] );
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, hoisted_26_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, deduped_32_1, deduped_34_1, deduped_35_1, hoisted_36_1, hoisted_37_1, hoisted_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1;
+    deduped_54_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_53_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_52_1 := Source( cat_1 );
+    deduped_51_1 := deduped_53_1[2];
+    deduped_50_1 := DataTables( deduped_52_1 );
+    deduped_49_1 := DefiningTripleOfUnderlyingQuiver( deduped_52_1 );
+    deduped_48_1 := deduped_50_1[2];
+    deduped_47_1 := deduped_50_1[1];
+    deduped_46_1 := [ 0 .. deduped_49_1[2] - 1 ];
+    deduped_45_1 := [ 0 .. deduped_49_1[1] - 1 ];
+    deduped_44_1 := [ 0 .. deduped_47_1[2] - 1 ];
+    deduped_2_1 := List( deduped_54_1[1], Length );
+    deduped_1_1 := List( deduped_53_1[1], Length );
+    deduped_43_1 := Concatenation( List( deduped_45_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
           end ) );
-    deduped_36_1 := Product( deduped_37_1 );
-    deduped_4_1 := List( deduped_45_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    deduped_42_1 := Product( deduped_43_1 );
+    deduped_7_1 := List( [ 0 .. deduped_47_1[1] - 1 ], function ( i_2 )
+            return CreateCapCategoryObjectWithAttributes( deduped_52_1, IndexOfObject, i_2 );
         end );
-    deduped_35_1 := [ 0 .. Sum( List( deduped_40_1, function ( j_2 )
-                    return deduped_4_1[1 + j_2];
+    deduped_3_1 := deduped_49_1[3];
+    deduped_6_1 := List( deduped_46_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][1];
+        end );
+    deduped_4_1 := List( deduped_46_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][2];
+        end );
+    deduped_8_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[1 + deduped_6_1[deduped_2_2]] ) );
+        end );
+    deduped_41_1 := [ 0 .. Sum( List( deduped_46_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_34_1 := [ 0 .. deduped_36_1 - 1 ];
-    deduped_10_1 := List( deduped_39_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
-                  end ) );
+    deduped_40_1 := [ 0 .. deduped_42_1 - 1 ];
+    deduped_39_1 := [ 0 .. Sum( List( deduped_46_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_3_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_20_1 := List( deduped_45_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[deduped_2_2] ) );
         end );
-    deduped_9_1 := deduped_43_1[3];
-    hoisted_32_1 := Concatenation( List( deduped_40_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_4_1[deduped_2_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_37_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_37_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_34_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    deduped_14_1 := deduped_42_1[3];
-    deduped_15_1 := List( deduped_38_1, function ( i_2 )
-            return deduped_14_1[1 + i_2];
+    deduped_19_1 := List( deduped_45_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
         end );
-    hoisted_29_1 := List( deduped_46_1, function ( i_2 )
-            return deduped_15_1[1 + i_2];
-        end );
-    deduped_7_1 := deduped_42_1[2];
-    deduped_13_1 := List( deduped_38_1, function ( i_2 )
-            return deduped_7_1[1 + i_2];
-        end );
-    hoisted_28_1 := List( deduped_46_1, function ( i_2 )
-            return deduped_13_1[1 + i_2];
-        end );
-    deduped_19_1 := List( deduped_49_1[2], AsList );
-    hoisted_17_1 := List( deduped_38_1, function ( i_2 )
+    deduped_14_1 := deduped_48_1[3];
+    deduped_11_1 := deduped_48_1[2];
+    deduped_16_1 := List( deduped_44_1, function ( i_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + i_2;
-            return CreateCapCategoryMorphismWithAttributes( deduped_47_1, CreateCapCategoryObjectWithAttributes( deduped_47_1, IndexOfObject, deduped_7_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_47_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
+            return CreateCapCategoryMorphismWithAttributes( deduped_52_1, CreateCapCategoryObjectWithAttributes( deduped_52_1, IndexOfObject, deduped_11_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_52_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
         end );
-    deduped_18_1 := List( deduped_46_1, function ( i_2 )
-            return hoisted_17_1[1 + i_2];
+    deduped_15_1 := deduped_48_1[1];
+    deduped_35_1 := List( deduped_46_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_19_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_19_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
         end );
-    deduped_12_1 := deduped_42_1[1];
-    hoisted_31_1 := Concatenation( List( deduped_40_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
-              deduped_10_2 := 1 + j_2;
-              deduped_9_2 := deduped_4_1[deduped_10_2];
-              deduped_8_2 := deduped_46_1[deduped_10_2];
-              deduped_7_2 := hoisted_29_1[deduped_10_2];
-              deduped_6_2 := hoisted_28_1[deduped_10_2];
-              deduped_5_2 := deduped_12_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_13_1[deduped_4_2] and deduped_7_2 = deduped_15_1[deduped_4_2] then
-                              return deduped_8_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_9_2, [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_9_2, deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_8_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    deduped_6_1 := Concatenation( List( deduped_40_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_4_1[1 + j_2] - 1 ] ), deduped_36_1 );
-          end ) );
-    hoisted_33_1 := List( deduped_35_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_31_1[deduped_3_2];
-            hoisted_1_2 := hoisted_32_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
+    deduped_24_1 := List( IndicesOfGeneratingMorphisms( deduped_52_1 ), function ( i_2 )
+            return deduped_16_1[1 + i_2];
         end );
-    deduped_11_1 := Concatenation( List( deduped_39_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], i_2 );
-          end ) );
-    deduped_8_1 := List( deduped_45_1, AsList );
-    hoisted_25_1 := Concatenation( List( deduped_40_1, function ( j_2 )
+    deduped_34_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_24_1[deduped_2_2] ) );
+        end );
+    hoisted_37_1 := Concatenation( List( deduped_46_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      return deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)] )];
-                  end );
-          end ) );
-    deduped_26_1 := List( deduped_35_1, function ( j_2 )
-            return Product( hoisted_25_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_23_1 := Concatenation( List( deduped_40_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_35_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_34_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_37_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_37_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_34_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_43_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_40_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_20_1 := Concatenation( List( deduped_40_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3;
-                      deduped_9_3 := deduped_12_1[1 + deduped_11_1[(1 + (hoisted_1_2[1 + i_3] + hoisted_2_2))]];
-                      deduped_8_3 := 1 + deduped_9_3;
-                      deduped_7_3 := deduped_15_1[deduped_8_3];
-                      deduped_6_3 := deduped_13_1[deduped_8_3];
-                      deduped_5_3 := deduped_12_1[1 + deduped_6_3];
+    deduped_25_1 := List( deduped_54_1[2], AsList );
+    deduped_23_1 := List( deduped_44_1, function ( i_2 )
+            return deduped_14_1[1 + i_2];
+        end );
+    deduped_22_1 := List( deduped_44_1, function ( i_2 )
+            return deduped_11_1[1 + i_2];
+        end );
+    deduped_18_1 := deduped_48_1[4];
+    hoisted_36_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_34_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_35_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
                       deduped_4_3 := 1 + deduped_5_3;
                       if IdFunc( function (  )
-                                  if deduped_6_3 = deduped_13_1[deduped_4_3] and deduped_7_3 = deduped_15_1[deduped_4_3] then
-                                      return deduped_9_3 = deduped_5_3;
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
                                   else
                                       return false;
                                   fi;
                                   return;
                               end )(  ) then
-                          return [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_3 )] - 1 ];
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
                       else
-                          return deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_4 )
-                                   if IndexOfObject( Source( mor_4 ) ) = deduped_6_3 and IndexOfObject( Range( mor_4 ) ) = deduped_7_3 then
-                                       return IndexOfMorphism( mor_4 ) = deduped_9_3;
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
                                    else
                                        return false;
                                    fi;
@@ -296,26 +257,118 @@ function ( cat_1, arg2_1, arg3_1 )
                       return;
                   end );
           end ) );
-    hoisted_24_1 := List( deduped_35_1, function ( i_2 )
+    deduped_10_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_42_1 );
+          end ) );
+    hoisted_38_1 := List( deduped_41_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_20_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_36_1[deduped_3_2];
+            hoisted_1_2 := hoisted_37_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    return CreateCapCategoryObjectWithAttributes( Range( cat_1 ), Length, Length( Filtered( deduped_34_1, function ( x_2 )
+    hoisted_31_1 := Concatenation( List( deduped_46_1, function ( m_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + m_2;
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_4_1[deduped_1_2]], deduped_2_1[1 + deduped_6_1[deduped_1_2]] );
+          end ) );
+    deduped_32_1 := List( deduped_39_1, function ( j_2 )
+            return Product( hoisted_31_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_21_1 := List( deduped_46_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_19_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_19_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    hoisted_13_1 := List( deduped_51_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_12_1 := List( deduped_51_1, AsList );
+    deduped_17_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + m_2;
+            return NTuple( 2, hoisted_12_1[deduped_1_2], ListWithIdenticalEntries( hoisted_13_1[deduped_1_2], deduped_16_1[1 + deduped_15_1[(1 + deduped_6_1[deduped_1_2])]] ) );
+        end );
+    hoisted_29_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_21_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_17_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_43_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_40_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_26_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_17_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_21_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_30_1 := List( deduped_41_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_26_1[deduped_3_2];
+            hoisted_1_2 := hoisted_29_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    return CreateCapCategoryObjectWithAttributes( Range( cat_1 ), Length, Length( Filtered( deduped_40_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_35_1, function ( j_3 )
+                            return hoisted_30_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_33_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
+                            return hoisted_38_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
                         end ) );
             end ) ) );
 end
@@ -328,202 +381,172 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, hoisted_17_1, deduped_18_1, deduped_19_1, hoisted_20_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, deduped_26_1, deduped_28_1, deduped_29_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, deduped_34_1, deduped_35_1, hoisted_36_1, hoisted_37_1, hoisted_40_1, hoisted_41_1, deduped_43_1, hoisted_45_1, deduped_46_1, hoisted_47_1, deduped_48_1, hoisted_52_1, hoisted_53_1, hoisted_54_1, hoisted_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, hoisted_61_1, hoisted_62_1, hoisted_63_1, hoisted_64_1, deduped_65_1, hoisted_67_1, hoisted_68_1, hoisted_69_1, hoisted_70_1, hoisted_71_1, hoisted_72_1, deduped_73_1, deduped_74_1, deduped_75_1, deduped_76_1, deduped_77_1, deduped_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1, deduped_95_1, deduped_96_1, deduped_97_1, deduped_98_1, deduped_99_1, deduped_100_1, deduped_101_1;
-    deduped_101_1 := Source( cat_1 );
-    deduped_100_1 := ListOfValues( ValuesOnAllObjects( alpha_1 ) );
-    deduped_99_1 := ValuesOfPreSheaf( Source( beta_1 ) );
-    deduped_98_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_97_1 := IndicesOfGeneratingMorphisms( deduped_101_1 );
-    deduped_96_1 := DefiningTripleOfUnderlyingQuiver( deduped_101_1 );
-    deduped_95_1 := ValuesOfPreSheaf( Range( beta_1 ) );
-    deduped_94_1 := DataTables( deduped_101_1 );
-    deduped_93_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_92_1 := deduped_98_1[2];
-    deduped_91_1 := deduped_94_1[2];
-    deduped_90_1 := deduped_93_1[2];
-    deduped_89_1 := deduped_94_1[1];
-    deduped_88_1 := [ 1 .. Length( deduped_100_1 ) ];
-    deduped_87_1 := [ 0 .. deduped_96_1[2] - 1 ];
-    deduped_86_1 := [ 0 .. deduped_96_1[1] - 1 ];
-    deduped_85_1 := [ 0 .. deduped_89_1[2] - 1 ];
-    deduped_35_1 := List( deduped_99_1[1], Length );
-    deduped_34_1 := List( deduped_98_1[1], Length );
-    deduped_2_1 := [ 0 .. deduped_89_1[1] - 1 ];
-    deduped_84_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_34_1[1 + i_2], deduped_35_1[SafeUniquePosition( deduped_2_1, i_2 )] );
-          end ) );
-    deduped_1_1 := List( deduped_93_1[1], Length );
-    deduped_83_1 := Sum( List( deduped_86_1, function ( i_2 )
-              return deduped_1_1[1 + i_2];
-          end ) );
-    deduped_82_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], deduped_35_1[SafeUniquePosition( deduped_2_1, i_2 )] );
-          end ) );
-    deduped_3_1 := List( deduped_95_1[1], Length );
-    deduped_81_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], deduped_3_1[SafeUniquePosition( deduped_2_1, i_2 )] );
-          end ) );
-    deduped_80_1 := Product( deduped_84_1 );
-    deduped_79_1 := Product( deduped_81_1 );
-    deduped_56_1 := List( deduped_92_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, hoisted_26_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, deduped_32_1, deduped_34_1, deduped_35_1, hoisted_36_1, hoisted_37_1, hoisted_38_1, deduped_39_1, deduped_40_1, hoisted_41_1, hoisted_42_1, hoisted_45_1, hoisted_46_1, hoisted_49_1, hoisted_50_1, hoisted_51_1, deduped_52_1, deduped_53_1, deduped_54_1, hoisted_55_1, deduped_56_1, hoisted_59_1, hoisted_60_1, hoisted_61_1, hoisted_62_1, deduped_63_1, deduped_64_1, hoisted_65_1, hoisted_66_1, deduped_67_1, deduped_68_1, hoisted_69_1, hoisted_70_1, hoisted_71_1, hoisted_72_1, deduped_73_1, deduped_75_1, deduped_76_1, hoisted_77_1, hoisted_78_1, hoisted_79_1, hoisted_80_1, hoisted_81_1, hoisted_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1, deduped_95_1, deduped_96_1, deduped_97_1, deduped_98_1, deduped_99_1, deduped_100_1, deduped_101_1, deduped_102_1, deduped_103_1, deduped_104_1, deduped_105_1, deduped_106_1, deduped_107_1, deduped_108_1, deduped_109_1, deduped_110_1, deduped_111_1, deduped_112_1, deduped_113_1, deduped_114_1;
+    deduped_114_1 := Source( cat_1 );
+    deduped_113_1 := ListOfValues( ValuesOnAllObjects( alpha_1 ) );
+    deduped_112_1 := ValuesOfPreSheaf( Source( beta_1 ) );
+    deduped_111_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_110_1 := DataTables( deduped_114_1 );
+    deduped_109_1 := DefiningTripleOfUnderlyingQuiver( deduped_114_1 );
+    deduped_108_1 := ValuesOfPreSheaf( Range( beta_1 ) );
+    deduped_107_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_106_1 := deduped_111_1[2];
+    deduped_105_1 := deduped_107_1[2];
+    deduped_104_1 := deduped_110_1[2];
+    deduped_103_1 := deduped_109_1[1];
+    deduped_102_1 := deduped_110_1[1];
+    deduped_101_1 := [ 1 .. deduped_103_1 ];
+    deduped_100_1 := [ 0 .. deduped_103_1 - 1 ];
+    deduped_99_1 := [ 0 .. deduped_109_1[2] - 1 ];
+    deduped_98_1 := [ 0 .. deduped_102_1[2] - 1 ];
+    deduped_1_1 := List( deduped_107_1[1], Length );
+    deduped_97_1 := List( deduped_100_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
         end );
-    deduped_78_1 := [ 0 .. Sum( List( deduped_87_1, function ( j_2 )
-                    return deduped_56_1[1 + j_2];
+    deduped_40_1 := List( deduped_112_1[1], Length );
+    deduped_39_1 := List( deduped_111_1[1], Length );
+    deduped_96_1 := Concatenation( List( deduped_100_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_39_1[deduped_1_2], deduped_40_1[deduped_1_2] );
+          end ) );
+    deduped_95_1 := Sum( deduped_97_1 );
+    deduped_94_1 := Concatenation( List( deduped_100_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_40_1[deduped_1_2] );
+          end ) );
+    deduped_2_1 := List( deduped_108_1[1], Length );
+    deduped_93_1 := Concatenation( List( deduped_100_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
+          end ) );
+    deduped_92_1 := Product( deduped_96_1 );
+    deduped_91_1 := Product( deduped_93_1 );
+    deduped_7_1 := List( [ 0 .. deduped_102_1[1] - 1 ], function ( i_2 )
+            return CreateCapCategoryObjectWithAttributes( deduped_114_1, IndexOfObject, i_2 );
+        end );
+    deduped_3_1 := deduped_109_1[3];
+    deduped_6_1 := List( deduped_99_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][1];
+        end );
+    deduped_4_1 := List( deduped_99_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][2];
+        end );
+    deduped_63_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_39_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[1 + deduped_6_1[deduped_2_2]] ) );
+        end );
+    deduped_90_1 := [ 0 .. Sum( List( deduped_99_1, function ( i_2 )
+                    return deduped_63_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_77_1 := [ 0 .. deduped_83_1 - 1 ];
-    deduped_4_1 := List( deduped_90_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    deduped_89_1 := [ 0 .. deduped_95_1 - 1 ];
+    deduped_8_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[1 + deduped_6_1[deduped_2_2]] ) );
         end );
-    deduped_76_1 := [ 0 .. Sum( List( deduped_87_1, function ( j_2 )
-                    return deduped_4_1[1 + j_2];
+    deduped_88_1 := [ 0 .. Sum( List( deduped_99_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_75_1 := [ 0 .. deduped_80_1 - 1 ];
-    deduped_74_1 := [ 0 .. Product( deduped_82_1 ) - 1 ];
-    deduped_73_1 := [ 0 .. deduped_79_1 - 1 ];
-    deduped_10_1 := List( deduped_86_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
-                  end ) );
+    deduped_87_1 := [ 0 .. deduped_92_1 - 1 ];
+    deduped_86_1 := [ 0 .. Product( deduped_94_1 ) - 1 ];
+    deduped_85_1 := [ 0 .. deduped_91_1 - 1 ];
+    deduped_84_1 := [ 0 .. Sum( List( deduped_99_1, function ( m_2 )
+                    return deduped_39_1[1 + deduped_3_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_83_1 := [ 0 .. Sum( List( deduped_99_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_3_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_20_1 := List( deduped_100_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[deduped_2_2] ) );
         end );
-    deduped_9_1 := deduped_96_1[3];
-    hoisted_32_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_4_1[deduped_2_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_81_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_81_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_73_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    deduped_14_1 := deduped_91_1[3];
-    deduped_15_1 := List( deduped_85_1, function ( i_2 )
-            return deduped_14_1[1 + i_2];
-        end );
-    deduped_29_1 := List( deduped_97_1, function ( i_2 )
-            return deduped_15_1[1 + i_2];
-        end );
-    deduped_7_1 := deduped_91_1[2];
-    deduped_13_1 := List( deduped_85_1, function ( i_2 )
-            return deduped_7_1[1 + i_2];
-        end );
-    deduped_28_1 := List( deduped_97_1, function ( i_2 )
-            return deduped_13_1[1 + i_2];
-        end );
-    deduped_19_1 := List( deduped_95_1[2], AsList );
-    hoisted_17_1 := List( deduped_85_1, function ( i_2 )
+    deduped_14_1 := deduped_104_1[3];
+    deduped_11_1 := deduped_104_1[2];
+    deduped_16_1 := List( deduped_98_1, function ( i_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + i_2;
-            return CreateCapCategoryMorphismWithAttributes( deduped_101_1, CreateCapCategoryObjectWithAttributes( deduped_101_1, IndexOfObject, deduped_7_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_101_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
+            return CreateCapCategoryMorphismWithAttributes( deduped_114_1, CreateCapCategoryObjectWithAttributes( deduped_114_1, IndexOfObject, deduped_11_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_114_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
         end );
-    deduped_18_1 := List( deduped_97_1, function ( i_2 )
-            return hoisted_17_1[1 + i_2];
+    deduped_15_1 := deduped_104_1[1];
+    deduped_35_1 := List( deduped_99_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_97_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_97_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
         end );
-    deduped_12_1 := deduped_91_1[1];
-    hoisted_31_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
-              deduped_10_2 := 1 + j_2;
-              deduped_9_2 := deduped_4_1[deduped_10_2];
-              deduped_8_2 := deduped_97_1[deduped_10_2];
-              deduped_7_2 := deduped_29_1[deduped_10_2];
-              deduped_6_2 := deduped_28_1[deduped_10_2];
-              deduped_5_2 := deduped_12_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_13_1[deduped_4_2] and deduped_7_2 = deduped_15_1[deduped_4_2] then
-                              return deduped_8_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_9_2, [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_9_2, deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_8_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    deduped_6_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_4_1[1 + j_2] - 1 ] ), deduped_79_1 );
-          end ) );
-    hoisted_33_1 := List( deduped_76_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_31_1[deduped_3_2];
-            hoisted_1_2 := hoisted_32_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
+    deduped_24_1 := List( IndicesOfGeneratingMorphisms( deduped_114_1 ), function ( i_2 )
+            return deduped_16_1[1 + i_2];
         end );
-    deduped_11_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], i_2 );
-          end ) );
-    deduped_8_1 := List( deduped_90_1, AsList );
-    hoisted_25_1 := Concatenation( List( deduped_87_1, function ( j_2 )
+    deduped_34_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_24_1[deduped_2_2] ) );
+        end );
+    hoisted_37_1 := Concatenation( List( deduped_99_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      return deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)] )];
-                  end );
-          end ) );
-    deduped_26_1 := List( deduped_76_1, function ( j_2 )
-            return Product( hoisted_25_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_23_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_35_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_34_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_81_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_81_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_73_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_93_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_93_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_85_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_20_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3;
-                      deduped_9_3 := deduped_12_1[1 + deduped_11_1[(1 + (hoisted_1_2[1 + i_3] + hoisted_2_2))]];
-                      deduped_8_3 := 1 + deduped_9_3;
-                      deduped_7_3 := deduped_15_1[deduped_8_3];
-                      deduped_6_3 := deduped_13_1[deduped_8_3];
-                      deduped_5_3 := deduped_12_1[1 + deduped_6_3];
+    deduped_25_1 := List( deduped_108_1[2], AsList );
+    deduped_23_1 := List( deduped_98_1, function ( i_2 )
+            return deduped_14_1[1 + i_2];
+        end );
+    deduped_22_1 := List( deduped_98_1, function ( i_2 )
+            return deduped_11_1[1 + i_2];
+        end );
+    deduped_18_1 := deduped_104_1[4];
+    hoisted_36_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_34_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_35_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
                       deduped_4_3 := 1 + deduped_5_3;
                       if IdFunc( function (  )
-                                  if deduped_6_3 = deduped_13_1[deduped_4_3] and deduped_7_3 = deduped_15_1[deduped_4_3] then
-                                      return deduped_9_3 = deduped_5_3;
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
                                   else
                                       return false;
                                   fi;
                                   return;
                               end )(  ) then
-                          return [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_3 )] - 1 ];
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
                       else
-                          return deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_4 )
-                                   if IndexOfObject( Source( mor_4 ) ) = deduped_6_3 and IndexOfObject( Range( mor_4 ) ) = deduped_7_3 then
-                                       return IndexOfMorphism( mor_4 ) = deduped_9_3;
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
                                    else
                                        return false;
                                    fi;
@@ -533,250 +556,215 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                       return;
                   end );
           end ) );
-    hoisted_24_1 := List( deduped_76_1, function ( i_2 )
+    deduped_10_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_91_1 );
+          end ) );
+    hoisted_38_1 := List( deduped_88_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_20_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_36_1[deduped_3_2];
+            hoisted_1_2 := hoisted_37_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_72_1 := Filtered( deduped_73_1, function ( x_2 )
+    hoisted_31_1 := Concatenation( List( deduped_99_1, function ( m_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + m_2;
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_4_1[deduped_1_2]], deduped_2_1[1 + deduped_6_1[deduped_1_2]] );
+          end ) );
+    deduped_32_1 := List( deduped_83_1, function ( j_2 )
+            return Product( hoisted_31_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_21_1 := List( deduped_99_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_97_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_97_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    hoisted_13_1 := List( deduped_105_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_12_1 := List( deduped_105_1, AsList );
+    deduped_17_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + m_2;
+            return NTuple( 2, hoisted_12_1[deduped_1_2], ListWithIdenticalEntries( hoisted_13_1[deduped_1_2], deduped_16_1[1 + deduped_15_1[(1 + deduped_6_1[deduped_1_2])]] ) );
+        end );
+    hoisted_29_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_21_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_17_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_93_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_93_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_85_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_26_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_17_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_21_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_30_1 := List( deduped_88_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_26_1[deduped_3_2];
+            hoisted_1_2 := hoisted_29_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_82_1 := Filtered( deduped_85_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_76_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_83_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_76_1, function ( j_3 )
+                        return hoisted_30_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_83_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_33_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
+                        return hoisted_38_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
                     end ) );
         end );
-    hoisted_41_1 := List( deduped_77_1, function ( j_2 )
-            return Product( deduped_81_1{[ 1 .. j_2 ]} );
+    hoisted_46_1 := List( deduped_89_1, function ( j_2 )
+            return Product( deduped_93_1{[ 1 .. j_2 ]} );
         end );
-    hoisted_36_1 := List( ValuesOnAllObjects( beta_1 ), AsList );
-    hoisted_37_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], hoisted_36_1[SafeUniquePosition( deduped_2_1, i_2 )] );
+    hoisted_41_1 := List( ValuesOnAllObjects( beta_1 ), AsList );
+    hoisted_42_1 := Concatenation( List( deduped_100_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], hoisted_41_1[deduped_1_2] );
           end ) );
-    hoisted_40_1 := List( [ 1 .. deduped_83_1 ], function ( i_2 )
+    hoisted_45_1 := List( [ 1 .. deduped_95_1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, hoisted_3_2;
-            hoisted_3_2 := hoisted_37_1[i_2];
-            hoisted_2_2 := deduped_82_1[i_2];
-            hoisted_1_2 := Product( deduped_82_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_74_1, function ( i_3 )
+            hoisted_3_2 := hoisted_42_1[i_2];
+            hoisted_2_2 := deduped_94_1[i_2];
+            hoisted_1_2 := Product( deduped_94_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_86_1, function ( i_3 )
                     return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
                 end );
         end );
-    hoisted_55_1 := List( deduped_74_1, function ( i_2 )
+    hoisted_62_1 := List( deduped_86_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_77_1, function ( j_3 )
+            return Sum( deduped_89_1, function ( j_3 )
                     local deduped_1_3;
                     deduped_1_3 := 1 + j_3;
-                    return hoisted_40_1[deduped_1_3][hoisted_1_2] * hoisted_41_1[deduped_1_3];
+                    return hoisted_45_1[deduped_1_3][hoisted_1_2] * hoisted_46_1[deduped_1_3];
                 end );
         end );
-    hoisted_54_1 := List( deduped_77_1, function ( j_2 )
-            return Product( deduped_82_1{[ 1 .. j_2 ]} );
+    hoisted_61_1 := List( deduped_89_1, function ( j_2 )
+            return Product( deduped_94_1{[ 1 .. j_2 ]} );
         end );
-    deduped_48_1 := List( deduped_100_1, function ( logic_new_func_x_2 )
-            return Length( Range( logic_new_func_x_2 ) );
+    deduped_56_1 := List( deduped_100_1, function ( o_2 )
+            return deduped_39_1[1 + o_2];
         end );
-    deduped_43_1 := List( deduped_100_1, function ( logic_new_func_x_2 )
+    hoisted_51_1 := List( deduped_113_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_52_1 := Concatenation( List( deduped_88_1, function ( i_2 )
+    hoisted_50_1 := List( deduped_113_1, AsList );
+    deduped_52_1 := List( deduped_100_1, function ( o_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + o_2;
+            return NTuple( 2, hoisted_50_1[deduped_1_2], ListWithIdenticalEntries( hoisted_51_1[deduped_1_2], deduped_16_1[1 + deduped_15_1[deduped_1_2]] ) );
+        end );
+    hoisted_59_1 := Concatenation( List( deduped_101_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := Sum( deduped_48_1{[ 1 .. i_2 - 1 ]} );
-              hoisted_2_2 := [ deduped_3_2 .. deduped_3_2 + deduped_48_1[i_2] - 1 ];
-              hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( AsList( CAP_JIT_INCOMPLETE_LOGIC( deduped_100_1[i_2] ) ) );
-              return List( [ 0 .. deduped_43_1[i_2] - 1 ], function ( i_3 )
+              deduped_3_2 := Sum( deduped_56_1{[ 1 .. i_2 - 1 ]} );
+              hoisted_2_2 := [ deduped_3_2 .. deduped_3_2 + deduped_56_1[i_2] - 1 ];
+              hoisted_1_2 := deduped_52_1[i_2][1];
+              return List( [ 0 .. deduped_20_1[i_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + hoisted_2_2[(1 + hoisted_1_2[(1 + i_3)])];
-                      hoisted_2_3 := deduped_84_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_84_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_75_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_96_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_96_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_87_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    deduped_46_1 := List( deduped_99_1[2], AsList );
-    hoisted_47_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2, deduped_11_2;
-              deduped_11_2 := 1 + i_2;
-              deduped_10_2 := deduped_1_1[deduped_11_2];
-              deduped_9_2 := deduped_12_1[deduped_11_2];
-              deduped_8_2 := 1 + deduped_9_2;
-              deduped_7_2 := deduped_15_1[deduped_8_2];
-              deduped_6_2 := deduped_13_1[deduped_8_2];
-              deduped_5_2 := deduped_12_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_13_1[deduped_4_2] and deduped_7_2 = deduped_15_1[deduped_4_2] then
-                              return deduped_9_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_10_2, [ 0 .. deduped_35_1[SafeUniquePosition( deduped_2_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_10_2, deduped_46_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_9_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    hoisted_45_1 := Concatenation( List( deduped_88_1, function ( i_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_43_1[i_2] - 1 ] ), deduped_80_1 );
-          end ) );
-    hoisted_53_1 := List( [ 0 .. Sum( List( deduped_88_1, function ( i_2 )
-                      return Length( [ 0 .. deduped_43_1[i_2] - 1 ] );
-                  end ) ) - 1 ], function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_47_1[deduped_3_2];
-            hoisted_1_2 := hoisted_52_1[deduped_3_2];
-            return List( [ 0 .. hoisted_45_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
+    deduped_54_1 := List( deduped_112_1[2], AsList );
+    deduped_53_1 := List( deduped_100_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_39_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[deduped_2_2] ) );
         end );
-    hoisted_71_1 := List( deduped_75_1, function ( i_2 )
-            local hoisted_1_2;
-            hoisted_1_2 := 1 + i_2;
-            return hoisted_55_1[1 + Sum( deduped_77_1, function ( j_3 )
-                       local deduped_1_3;
-                       deduped_1_3 := (1 + j_3);
-                       return hoisted_53_1[deduped_1_3][hoisted_1_2] * hoisted_54_1[deduped_1_3];
-                   end )];
-        end );
-    deduped_59_1 := List( deduped_86_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_34_1[j_3];
-                  end ) );
-        end );
-    hoisted_68_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_59_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_56_1[deduped_2_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_84_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_84_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_75_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
+    hoisted_55_1 := Concatenation( List( deduped_101_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2;
+              deduped_4_2 := deduped_52_1[i_2];
+              hoisted_3_2 := List( deduped_53_1[i_2][2], function ( objC_3 )
+                      return deduped_15_1[1 + IndexOfObject( objC_3 )];
                   end );
-          end ) );
-    hoisted_67_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
-              deduped_10_2 := 1 + j_2;
-              deduped_9_2 := deduped_56_1[deduped_10_2];
-              deduped_8_2 := deduped_97_1[deduped_10_2];
-              deduped_7_2 := deduped_29_1[deduped_10_2];
-              deduped_6_2 := deduped_28_1[deduped_10_2];
-              deduped_5_2 := deduped_12_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_13_1[deduped_4_2] and deduped_7_2 = deduped_15_1[deduped_4_2] then
-                              return deduped_8_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_9_2, [ 0 .. deduped_35_1[SafeUniquePosition( deduped_2_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_9_2, deduped_46_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_8_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    deduped_57_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_56_1[1 + j_2] - 1 ] ), deduped_80_1 );
-          end ) );
-    hoisted_69_1 := List( deduped_78_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_67_1[deduped_3_2];
-            hoisted_1_2 := hoisted_68_1[deduped_3_2];
-            return List( [ 0 .. deduped_57_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_60_1 := Concatenation( List( deduped_86_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_34_1[1 + i_2], i_2 );
-          end ) );
-    deduped_58_1 := List( deduped_92_1, AsList );
-    hoisted_64_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_59_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_58_1[deduped_3_2];
-              return List( [ 0 .. deduped_56_1[deduped_3_2] - 1 ], function ( i_3 )
-                      return deduped_35_1[SafeUniquePosition( deduped_2_1, deduped_60_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)] )];
-                  end );
-          end ) );
-    deduped_65_1 := List( deduped_78_1, function ( j_2 )
-            return Product( hoisted_64_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_62_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_59_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_58_1[deduped_3_2];
-              return List( [ 0 .. deduped_56_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_84_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_84_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_75_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_61_1 := Concatenation( List( deduped_87_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_59_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_58_1[deduped_3_2];
-              return List( [ 0 .. deduped_56_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3;
-                      deduped_9_3 := deduped_12_1[1 + deduped_60_1[(1 + (hoisted_1_2[1 + i_3] + hoisted_2_2))]];
-                      deduped_8_3 := 1 + deduped_9_3;
-                      deduped_7_3 := deduped_15_1[deduped_8_3];
-                      deduped_6_3 := deduped_13_1[deduped_8_3];
-                      deduped_5_3 := deduped_12_1[1 + deduped_6_3];
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_20_1[i_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
                       deduped_4_3 := 1 + deduped_5_3;
                       if IdFunc( function (  )
-                                  if deduped_6_3 = deduped_13_1[deduped_4_3] and deduped_7_3 = deduped_15_1[deduped_4_3] then
-                                      return deduped_9_3 = deduped_5_3;
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
                                   else
                                       return false;
                                   fi;
                                   return;
                               end )(  ) then
-                          return [ 0 .. deduped_35_1[SafeUniquePosition( deduped_2_1, deduped_6_3 )] - 1 ];
+                          return [ 0 .. deduped_40_1[deduped_6_3] - 1 ];
                       else
-                          return deduped_46_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_4 )
-                                   if IndexOfObject( Source( mor_4 ) ) = deduped_6_3 and IndexOfObject( Range( mor_4 ) ) = deduped_7_3 then
-                                       return IndexOfMorphism( mor_4 ) = deduped_9_3;
+                          return deduped_54_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
                                    else
                                        return false;
                                    fi;
@@ -786,30 +774,214 @@ function ( cat_1, source_1, alpha_1, beta_1, range_1 )
                       return;
                   end );
           end ) );
-    hoisted_63_1 := List( deduped_78_1, function ( i_2 )
+    hoisted_49_1 := Concatenation( List( deduped_101_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_20_1[i_2][1], deduped_92_1 );
+          end ) );
+    hoisted_60_1 := List( [ 0 .. Sum( List( deduped_101_1, function ( i_2 )
+                      return deduped_20_1[i_2][1];
+                  end ) ) - 1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_61_1[deduped_3_2];
-            hoisted_1_2 := hoisted_62_1[deduped_3_2];
-            return List( [ 0 .. deduped_57_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_55_1[deduped_3_2];
+            hoisted_1_2 := hoisted_59_1[deduped_3_2];
+            return List( [ 0 .. hoisted_49_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_70_1 := Filtered( deduped_75_1, function ( x_2 )
+    hoisted_81_1 := List( deduped_87_1, function ( i_2 )
+            local hoisted_1_2;
+            hoisted_1_2 := 1 + i_2;
+            return hoisted_62_1[1 + Sum( deduped_89_1, function ( j_3 )
+                       local deduped_1_3;
+                       deduped_1_3 := (1 + j_3);
+                       return hoisted_60_1[deduped_1_3][hoisted_1_2] * hoisted_61_1[deduped_1_3];
+                   end )];
+        end );
+    deduped_76_1 := List( deduped_99_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_56_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_56_1[deduped_2_2] - 1 ], List( deduped_53_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    deduped_75_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_39_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_24_1[deduped_2_2] ) );
+        end );
+    hoisted_78_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_76_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_75_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_63_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_96_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_96_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_87_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_77_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_75_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_76_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_63_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_40_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_54_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    deduped_64_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_63_1[1 + i_2][1], deduped_92_1 );
+          end ) );
+    hoisted_79_1 := List( deduped_90_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_77_1[deduped_3_2];
+            hoisted_1_2 := hoisted_78_1[deduped_3_2];
+            return List( [ 0 .. deduped_64_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_72_1 := Concatenation( List( deduped_99_1, function ( m_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + m_2;
+              return ListWithIdenticalEntries( deduped_39_1[1 + deduped_4_1[deduped_1_2]], deduped_40_1[1 + deduped_6_1[deduped_1_2]] );
+          end ) );
+    deduped_73_1 := List( deduped_84_1, function ( j_2 )
+            return Product( hoisted_72_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_68_1 := List( deduped_99_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_56_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_56_1[deduped_2_2] - 1 ], List( deduped_53_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    hoisted_66_1 := List( deduped_106_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_65_1 := List( deduped_106_1, AsList );
+    deduped_67_1 := List( deduped_99_1, function ( m_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + m_2;
+            return NTuple( 2, hoisted_65_1[deduped_1_2], ListWithIdenticalEntries( hoisted_66_1[deduped_1_2], deduped_16_1[1 + deduped_15_1[(1 + deduped_6_1[deduped_1_2])]] ) );
+        end );
+    hoisted_70_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_68_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_67_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_63_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_96_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_96_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_87_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_69_1 := Concatenation( List( deduped_99_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_67_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_68_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_63_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_40_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_54_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_71_1 := List( deduped_90_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_69_1[deduped_3_2];
+            hoisted_1_2 := hoisted_70_1[deduped_3_2];
+            return List( [ 0 .. deduped_64_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_80_1 := Filtered( deduped_87_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_78_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_84_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_63_1[deduped_1_3][deduped_1_2] * deduped_65_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_78_1, function ( j_3 )
+                        return hoisted_71_1[deduped_1_3][deduped_1_2] * deduped_73_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_84_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_69_1[deduped_1_3][deduped_1_2] * deduped_65_1[deduped_1_3];
+                        return hoisted_79_1[deduped_1_3][deduped_1_2] * deduped_73_1[deduped_1_3];
                     end ) );
         end );
     return CreateCapCategoryMorphismWithAttributes( Range( cat_1 ), source_1, range_1, AsList, List( [ 0 .. Length( source_1 ) - 1 ], function ( x_2 )
-              return -1 + BigInt( SafePosition( hoisted_72_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_71_1[(1 + hoisted_70_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))])] ) ) );
+              return -1 + BigInt( SafePosition( hoisted_82_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_81_1[(1 + hoisted_80_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))])] ) ) );
           end ) );
 end
 ########
@@ -821,182 +993,143 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, hoisted_20_1, deduped_21_1, deduped_22_1, hoisted_23_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, deduped_29_1, hoisted_31_1, hoisted_32_1, hoisted_34_1, hoisted_35_1, hoisted_36_1, deduped_37_1, hoisted_38_1, hoisted_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1;
-    deduped_60_1 := ValuesOfPreSheaf( range_1 );
-    deduped_59_1 := ValuesOfPreSheaf( source_1 );
-    deduped_58_1 := Source( cat_1 );
-    deduped_57_1 := IndicesOfGeneratingMorphisms( deduped_58_1 );
-    deduped_56_1 := deduped_59_1[2];
-    deduped_55_1 := DataTables( deduped_58_1 );
-    deduped_54_1 := deduped_60_1[1];
-    deduped_53_1 := deduped_59_1[1];
-    deduped_52_1 := DefiningTripleOfUnderlyingQuiver( deduped_58_1 );
-    deduped_51_1 := deduped_55_1[2];
-    deduped_50_1 := deduped_55_1[1];
-    deduped_49_1 := ListOfValues( deduped_53_1 );
-    deduped_48_1 := deduped_52_1[1];
-    deduped_47_1 := [ 1 .. deduped_48_1 ];
-    deduped_46_1 := [ 0 .. deduped_52_1[2] - 1 ];
-    deduped_45_1 := [ 0 .. deduped_48_1 - 1 ];
-    deduped_44_1 := [ 0 .. deduped_50_1[2] - 1 ];
-    deduped_6_1 := List( deduped_54_1, Length );
-    deduped_5_1 := [ 0 .. deduped_50_1[1] - 1 ];
-    deduped_4_1 := List( deduped_53_1, Length );
-    deduped_43_1 := Concatenation( List( deduped_45_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_4_1[1 + i_2], deduped_6_1[SafeUniquePosition( deduped_5_1, i_2 )] );
+    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_13_1, deduped_14_1, hoisted_15_1, hoisted_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, deduped_26_1, deduped_27_1, deduped_28_1, hoisted_29_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, deduped_35_1, deduped_37_1, deduped_38_1, hoisted_39_1, hoisted_40_1, hoisted_41_1, deduped_42_1, hoisted_43_1, hoisted_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1;
+    deduped_65_1 := ValuesOfPreSheaf( range_1 );
+    deduped_64_1 := ValuesOfPreSheaf( source_1 );
+    deduped_63_1 := Source( cat_1 );
+    deduped_62_1 := deduped_64_1[2];
+    deduped_61_1 := DataTables( deduped_63_1 );
+    deduped_60_1 := deduped_65_1[1];
+    deduped_59_1 := deduped_64_1[1];
+    deduped_58_1 := DefiningTripleOfUnderlyingQuiver( deduped_63_1 );
+    deduped_57_1 := deduped_61_1[2];
+    deduped_56_1 := deduped_61_1[1];
+    deduped_55_1 := ListOfValues( deduped_59_1 );
+    deduped_54_1 := deduped_58_1[1];
+    deduped_53_1 := [ 1 .. deduped_54_1 ];
+    deduped_52_1 := [ 0 .. deduped_54_1 - 1 ];
+    deduped_51_1 := [ 0 .. deduped_58_1[2] - 1 ];
+    deduped_50_1 := [ 0 .. deduped_56_1[2] - 1 ];
+    deduped_5_1 := List( deduped_60_1, Length );
+    deduped_4_1 := List( deduped_59_1, Length );
+    deduped_49_1 := Concatenation( List( deduped_52_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_4_1[deduped_1_2], deduped_5_1[deduped_1_2] );
           end ) );
-    deduped_42_1 := Product( deduped_43_1 );
-    deduped_7_1 := List( deduped_56_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    deduped_48_1 := Product( deduped_49_1 );
+    deduped_10_1 := List( [ 0 .. deduped_56_1[1] - 1 ], function ( i_2 )
+            return CreateCapCategoryObjectWithAttributes( deduped_63_1, IndexOfObject, i_2 );
         end );
-    deduped_41_1 := [ 0 .. Sum( List( deduped_46_1, function ( j_2 )
-                    return deduped_7_1[1 + j_2];
+    deduped_6_1 := deduped_58_1[3];
+    deduped_9_1 := List( deduped_51_1, function ( m_2 )
+            return deduped_6_1[1 + m_2][1];
+        end );
+    deduped_7_1 := List( deduped_51_1, function ( m_2 )
+            return deduped_6_1[1 + m_2][2];
+        end );
+    deduped_11_1 := List( deduped_51_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_4_1[1 + deduped_7_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_10_1[1 + deduped_9_1[deduped_2_2]] ) );
+        end );
+    deduped_47_1 := [ 0 .. Sum( List( deduped_51_1, function ( i_2 )
+                    return deduped_11_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_40_1 := [ 0 .. deduped_42_1 - 1 ];
-    hoisted_39_1 := Range( cat_1 );
-    deduped_13_1 := List( deduped_45_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_4_1[j_3];
-                  end ) );
+    deduped_46_1 := [ 0 .. deduped_48_1 - 1 ];
+    deduped_45_1 := [ 0 .. Sum( List( deduped_51_1, function ( m_2 )
+                    return deduped_4_1[1 + deduped_6_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    hoisted_44_1 := Range( cat_1 );
+    deduped_23_1 := List( deduped_52_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_4_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_10_1[deduped_2_2] ) );
         end );
-    deduped_12_1 := deduped_52_1[3];
-    hoisted_35_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_13_1[1 + deduped_12_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_7_1[deduped_2_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_43_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_40_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    deduped_17_1 := deduped_51_1[3];
-    deduped_18_1 := List( deduped_44_1, function ( i_2 )
-            return deduped_17_1[1 + i_2];
+    deduped_22_1 := List( deduped_52_1, function ( o_2 )
+            return deduped_4_1[1 + o_2];
         end );
-    hoisted_32_1 := List( deduped_57_1, function ( i_2 )
-            return deduped_18_1[1 + i_2];
-        end );
-    deduped_10_1 := deduped_51_1[2];
-    deduped_16_1 := List( deduped_44_1, function ( i_2 )
-            return deduped_10_1[1 + i_2];
-        end );
-    hoisted_31_1 := List( deduped_57_1, function ( i_2 )
-            return deduped_16_1[1 + i_2];
-        end );
-    deduped_22_1 := List( deduped_60_1[2], AsList );
-    hoisted_20_1 := List( deduped_44_1, function ( i_2 )
+    deduped_17_1 := deduped_57_1[3];
+    deduped_14_1 := deduped_57_1[2];
+    deduped_19_1 := List( deduped_50_1, function ( i_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + i_2;
-            return CreateCapCategoryMorphismWithAttributes( deduped_58_1, CreateCapCategoryObjectWithAttributes( deduped_58_1, IndexOfObject, deduped_10_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_58_1, IndexOfObject, deduped_17_1[deduped_1_2] ), IndexOfMorphism, i_2 );
+            return CreateCapCategoryMorphismWithAttributes( deduped_63_1, CreateCapCategoryObjectWithAttributes( deduped_63_1, IndexOfObject, deduped_14_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_63_1, IndexOfObject, deduped_17_1[deduped_1_2] ), IndexOfMorphism, i_2 );
         end );
-    deduped_21_1 := List( deduped_57_1, function ( i_2 )
-            return hoisted_20_1[1 + i_2];
+    deduped_18_1 := deduped_57_1[1];
+    deduped_38_1 := List( deduped_51_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_7_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_22_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_22_1[deduped_2_2] - 1 ], List( deduped_23_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_19_1[1 + deduped_18_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
         end );
-    deduped_15_1 := deduped_51_1[1];
-    hoisted_34_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
-              deduped_10_2 := 1 + j_2;
-              deduped_9_2 := deduped_7_1[deduped_10_2];
-              deduped_8_2 := deduped_57_1[deduped_10_2];
-              deduped_7_2 := hoisted_32_1[deduped_10_2];
-              deduped_6_2 := hoisted_31_1[deduped_10_2];
-              deduped_5_2 := deduped_15_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_16_1[deduped_4_2] and deduped_7_2 = deduped_18_1[deduped_4_2] then
-                              return deduped_8_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_9_2, [ 0 .. deduped_6_1[SafeUniquePosition( deduped_5_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_9_2, deduped_22_1[SafeUniquePositionProperty( deduped_21_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_8_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    deduped_9_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_7_1[1 + j_2] - 1 ] ), deduped_42_1 );
-          end ) );
-    hoisted_36_1 := List( deduped_41_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_34_1[deduped_3_2];
-            hoisted_1_2 := hoisted_35_1[deduped_3_2];
-            return List( [ 0 .. deduped_9_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
+    deduped_27_1 := List( IndicesOfGeneratingMorphisms( deduped_63_1 ), function ( i_2 )
+            return deduped_19_1[1 + i_2];
         end );
-    deduped_14_1 := Concatenation( List( deduped_45_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_4_1[1 + i_2], i_2 );
-          end ) );
-    deduped_11_1 := List( deduped_56_1, AsList );
-    hoisted_28_1 := Concatenation( List( deduped_46_1, function ( j_2 )
+    deduped_37_1 := List( deduped_51_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_4_1[1 + deduped_7_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_27_1[deduped_2_2] ) );
+        end );
+    hoisted_40_1 := Concatenation( List( deduped_51_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
-                      return deduped_6_1[SafeUniquePosition( deduped_5_1, deduped_14_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)] )];
-                  end );
-          end ) );
-    deduped_29_1 := List( deduped_41_1, function ( j_2 )
-            return Product( hoisted_28_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_26_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_38_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_37_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_11_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_43_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_40_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_49_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_49_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_46_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_23_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3;
-                      deduped_9_3 := deduped_15_1[1 + deduped_14_1[(1 + (hoisted_1_2[1 + i_3] + hoisted_2_2))]];
-                      deduped_8_3 := 1 + deduped_9_3;
-                      deduped_7_3 := deduped_18_1[deduped_8_3];
-                      deduped_6_3 := deduped_16_1[deduped_8_3];
-                      deduped_5_3 := deduped_15_1[1 + deduped_6_3];
+    deduped_28_1 := List( deduped_65_1[2], AsList );
+    deduped_26_1 := List( deduped_50_1, function ( i_2 )
+            return deduped_17_1[1 + i_2];
+        end );
+    deduped_25_1 := List( deduped_50_1, function ( i_2 )
+            return deduped_14_1[1 + i_2];
+        end );
+    deduped_21_1 := deduped_57_1[4];
+    hoisted_39_1 := Concatenation( List( deduped_51_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_37_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_38_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_11_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_21_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_26_1[deduped_9_3];
+                      deduped_7_3 := deduped_25_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_18_1[deduped_6_3];
                       deduped_4_3 := 1 + deduped_5_3;
                       if IdFunc( function (  )
-                                  if deduped_6_3 = deduped_16_1[deduped_4_3] and deduped_7_3 = deduped_18_1[deduped_4_3] then
-                                      return deduped_9_3 = deduped_5_3;
+                                  if deduped_7_3 = deduped_25_1[deduped_4_3] and deduped_8_3 = deduped_26_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
                                   else
                                       return false;
                                   fi;
                                   return;
                               end )(  ) then
-                          return [ 0 .. deduped_6_1[SafeUniquePosition( deduped_5_1, deduped_6_3 )] - 1 ];
+                          return [ 0 .. deduped_5_1[deduped_6_3] - 1 ];
                       else
-                          return deduped_22_1[SafeUniquePositionProperty( deduped_21_1, function ( mor_4 )
-                                   if IndexOfObject( Source( mor_4 ) ) = deduped_6_3 and IndexOfObject( Range( mor_4 ) ) = deduped_7_3 then
-                                       return IndexOfMorphism( mor_4 ) = deduped_9_3;
+                          return deduped_28_1[SafeUniquePositionProperty( deduped_27_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
                                    else
                                        return false;
                                    fi;
@@ -1006,38 +1139,130 @@ function ( cat_1, source_1, range_1, alpha_1 )
                       return;
                   end );
           end ) );
-    hoisted_27_1 := List( deduped_41_1, function ( i_2 )
+    deduped_13_1 := Concatenation( List( deduped_51_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_11_1[1 + i_2][1], deduped_48_1 );
+          end ) );
+    hoisted_41_1 := List( deduped_47_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_23_1[deduped_3_2];
-            hoisted_1_2 := hoisted_26_1[deduped_3_2];
-            return List( [ 0 .. deduped_9_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_39_1[deduped_3_2];
+            hoisted_1_2 := hoisted_40_1[deduped_3_2];
+            return List( [ 0 .. deduped_13_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_38_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_40_1, function ( x_2 )
+    hoisted_34_1 := Concatenation( List( deduped_51_1, function ( m_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + m_2;
+              return ListWithIdenticalEntries( deduped_4_1[1 + deduped_7_1[deduped_1_2]], deduped_5_1[1 + deduped_9_1[deduped_1_2]] );
+          end ) );
+    deduped_35_1 := List( deduped_45_1, function ( j_2 )
+            return Product( hoisted_34_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_24_1 := List( deduped_51_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_9_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_22_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_22_1[deduped_2_2] - 1 ], List( deduped_23_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_19_1[1 + deduped_18_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    hoisted_16_1 := List( deduped_62_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_15_1 := List( deduped_62_1, AsList );
+    deduped_20_1 := List( deduped_51_1, function ( m_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + m_2;
+            return NTuple( 2, hoisted_15_1[deduped_1_2], ListWithIdenticalEntries( hoisted_16_1[deduped_1_2], deduped_19_1[1 + deduped_18_1[(1 + deduped_9_1[deduped_1_2])]] ) );
+        end );
+    hoisted_32_1 := Concatenation( List( deduped_51_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_24_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_20_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_11_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_49_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_49_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_46_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_29_1 := Concatenation( List( deduped_51_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_20_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_24_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_11_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_21_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_26_1[deduped_9_3];
+                      deduped_7_3 := deduped_25_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_18_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_25_1[deduped_4_3] and deduped_8_3 = deduped_26_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_5_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_28_1[SafeUniquePositionProperty( deduped_27_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_33_1 := List( deduped_47_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_29_1[deduped_3_2];
+            hoisted_1_2 := hoisted_32_1[deduped_3_2];
+            return List( [ 0 .. deduped_13_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_43_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_46_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_41_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_45_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_27_1[deduped_1_3][deduped_1_2] * deduped_29_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_41_1, function ( j_3 )
+                            return hoisted_33_1[deduped_1_3][deduped_1_2] * deduped_35_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_45_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_36_1[deduped_1_3][deduped_1_2] * deduped_29_1[deduped_1_3];
+                            return hoisted_41_1[deduped_1_3][deduped_1_2] * deduped_35_1[deduped_1_3];
                         end ) );
             end )[1 + AsList( alpha_1 )[(1 + CAP_JIT_INCOMPLETE_LOGIC( [ 0 .. (Length( Source( alpha_1 ) ) - 1) ][1] ))]] );
-    deduped_3_1 := List( deduped_49_1, Length );
-    deduped_37_1 := List( deduped_47_1, function ( i_2 )
-            return Product( deduped_43_1{[ 1 + Sum( deduped_3_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_3_1{[ 1 .. i_2 ]} ) ]} );
+    deduped_3_1 := List( deduped_55_1, Length );
+    deduped_42_1 := List( deduped_53_1, function ( i_2 )
+            return Product( deduped_49_1{[ 1 + Sum( deduped_3_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_3_1{[ 1 .. i_2 ]} ) ]} );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, List( deduped_47_1, function ( i_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, List( deduped_53_1, function ( i_2 )
               local deduped_1_2, hoisted_2_2, deduped_3_2;
               deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-              hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( hoisted_38_1, Product( deduped_37_1{[ 1 .. deduped_3_2 - 1 ]} ) ), deduped_37_1[deduped_3_2] ) );
-              deduped_1_2 := deduped_6_1[i_2];
-              return CreateCapCategoryMorphismWithAttributes( hoisted_39_1, deduped_49_1[i_2], deduped_54_1[i_2], AsList, List( [ 0 .. deduped_3_1[i_2] - 1 ], function ( i_3 )
+              hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( hoisted_43_1, Product( deduped_42_1{[ 1 .. deduped_3_2 - 1 ]} ) ), deduped_42_1[deduped_3_2] ) );
+              deduped_1_2 := deduped_5_1[i_2];
+              return CreateCapCategoryMorphismWithAttributes( hoisted_44_1, deduped_55_1[i_2], deduped_60_1[i_2], AsList, List( [ 0 .. deduped_3_1[i_2] - 1 ], function ( i_3 )
                         return REM_INT( QUO_INT( hoisted_2_2, deduped_1_2 ^ i_3 ), deduped_1_2 );
                     end ) );
           end ) );
@@ -1051,181 +1276,142 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, deduped_15_1, hoisted_17_1, deduped_18_1, deduped_19_1, hoisted_20_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, deduped_26_1, hoisted_28_1, hoisted_29_1, hoisted_31_1, hoisted_32_1, hoisted_33_1, deduped_36_1, deduped_37_1, hoisted_38_1, hoisted_41_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1;
-    deduped_65_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_64_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_63_1 := Source( cat_1 );
-    deduped_62_1 := IndicesOfGeneratingMorphisms( deduped_63_1 );
-    deduped_61_1 := deduped_64_1[2];
-    deduped_60_1 := deduped_65_1[1];
-    deduped_59_1 := DataTables( deduped_63_1 );
-    deduped_58_1 := deduped_64_1[1];
-    deduped_57_1 := DefiningTripleOfUnderlyingQuiver( deduped_63_1 );
-    deduped_56_1 := ListOfValues( deduped_58_1 );
-    deduped_55_1 := deduped_59_1[2];
-    deduped_54_1 := deduped_59_1[1];
-    deduped_53_1 := deduped_57_1[1];
-    deduped_52_1 := [ 1 .. deduped_53_1 ];
-    deduped_51_1 := [ 0 .. deduped_57_1[2] - 1 ];
-    deduped_50_1 := [ 0 .. deduped_53_1 - 1 ];
-    deduped_49_1 := [ 0 .. deduped_54_1[2] - 1 ];
-    deduped_3_1 := List( deduped_60_1, Length );
-    deduped_2_1 := [ 0 .. deduped_54_1[1] - 1 ];
-    deduped_1_1 := List( deduped_58_1, Length );
-    deduped_48_1 := Concatenation( List( deduped_50_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], deduped_3_1[SafeUniquePosition( deduped_2_1, i_2 )] );
+    local deduped_1_1, deduped_2_1, deduped_3_1, deduped_4_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, deduped_25_1, hoisted_26_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, deduped_32_1, deduped_34_1, deduped_35_1, hoisted_36_1, hoisted_37_1, hoisted_38_1, deduped_41_1, deduped_42_1, hoisted_43_1, hoisted_46_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1, deduped_64_1, deduped_65_1, deduped_66_1, deduped_67_1, deduped_68_1, deduped_69_1, deduped_70_1;
+    deduped_70_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_69_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_68_1 := Source( cat_1 );
+    deduped_67_1 := deduped_69_1[2];
+    deduped_66_1 := DataTables( deduped_68_1 );
+    deduped_65_1 := deduped_70_1[1];
+    deduped_64_1 := deduped_69_1[1];
+    deduped_63_1 := DefiningTripleOfUnderlyingQuiver( deduped_68_1 );
+    deduped_62_1 := ListOfValues( deduped_64_1 );
+    deduped_61_1 := deduped_66_1[2];
+    deduped_60_1 := deduped_66_1[1];
+    deduped_59_1 := deduped_63_1[1];
+    deduped_58_1 := [ 1 .. deduped_59_1 ];
+    deduped_57_1 := [ 0 .. deduped_63_1[2] - 1 ];
+    deduped_56_1 := [ 0 .. deduped_59_1 - 1 ];
+    deduped_55_1 := [ 0 .. deduped_60_1[2] - 1 ];
+    deduped_2_1 := List( deduped_65_1, Length );
+    deduped_1_1 := List( deduped_64_1, Length );
+    deduped_54_1 := Concatenation( List( deduped_56_1, function ( o_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + o_2;
+              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
           end ) );
-    deduped_47_1 := Product( deduped_48_1 );
-    deduped_4_1 := List( deduped_61_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    deduped_53_1 := Product( deduped_54_1 );
+    deduped_7_1 := List( [ 0 .. deduped_60_1[1] - 1 ], function ( i_2 )
+            return CreateCapCategoryObjectWithAttributes( deduped_68_1, IndexOfObject, i_2 );
         end );
-    deduped_46_1 := [ 0 .. Sum( List( deduped_51_1, function ( j_2 )
-                    return deduped_4_1[1 + j_2];
+    deduped_3_1 := deduped_63_1[3];
+    deduped_6_1 := List( deduped_57_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][1];
+        end );
+    deduped_4_1 := List( deduped_57_1, function ( m_2 )
+            return deduped_3_1[1 + m_2][2];
+        end );
+    deduped_8_1 := List( deduped_57_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[1 + deduped_6_1[deduped_2_2]] ) );
+        end );
+    deduped_52_1 := [ 0 .. Sum( List( deduped_57_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_45_1 := [ 0 .. deduped_47_1 - 1 ];
-    deduped_10_1 := List( deduped_50_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
-                  end ) );
+    deduped_51_1 := [ 0 .. deduped_53_1 - 1 ];
+    deduped_50_1 := [ 0 .. Sum( List( deduped_57_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_3_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_20_1 := List( deduped_56_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_7_1[deduped_2_2] ) );
         end );
-    deduped_9_1 := deduped_57_1[3];
-    hoisted_32_1 := Concatenation( List( deduped_51_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_4_1[deduped_2_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_48_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_48_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_45_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    deduped_14_1 := deduped_55_1[3];
-    deduped_15_1 := List( deduped_49_1, function ( i_2 )
-            return deduped_14_1[1 + i_2];
+    deduped_19_1 := List( deduped_56_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
         end );
-    hoisted_29_1 := List( deduped_62_1, function ( i_2 )
-            return deduped_15_1[1 + i_2];
-        end );
-    deduped_7_1 := deduped_55_1[2];
-    deduped_13_1 := List( deduped_49_1, function ( i_2 )
-            return deduped_7_1[1 + i_2];
-        end );
-    hoisted_28_1 := List( deduped_62_1, function ( i_2 )
-            return deduped_13_1[1 + i_2];
-        end );
-    deduped_19_1 := List( deduped_65_1[2], AsList );
-    hoisted_17_1 := List( deduped_49_1, function ( i_2 )
+    deduped_14_1 := deduped_61_1[3];
+    deduped_11_1 := deduped_61_1[2];
+    deduped_16_1 := List( deduped_55_1, function ( i_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + i_2;
-            return CreateCapCategoryMorphismWithAttributes( deduped_63_1, CreateCapCategoryObjectWithAttributes( deduped_63_1, IndexOfObject, deduped_7_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_63_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
+            return CreateCapCategoryMorphismWithAttributes( deduped_68_1, CreateCapCategoryObjectWithAttributes( deduped_68_1, IndexOfObject, deduped_11_1[deduped_1_2] ), CreateCapCategoryObjectWithAttributes( deduped_68_1, IndexOfObject, deduped_14_1[deduped_1_2] ), IndexOfMorphism, i_2 );
         end );
-    deduped_18_1 := List( deduped_62_1, function ( i_2 )
-            return hoisted_17_1[1 + i_2];
+    deduped_15_1 := deduped_61_1[1];
+    deduped_35_1 := List( deduped_57_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_4_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_19_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_19_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
         end );
-    deduped_12_1 := deduped_55_1[1];
-    hoisted_31_1 := Concatenation( List( deduped_51_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
-              deduped_10_2 := 1 + j_2;
-              deduped_9_2 := deduped_4_1[deduped_10_2];
-              deduped_8_2 := deduped_62_1[deduped_10_2];
-              deduped_7_2 := hoisted_29_1[deduped_10_2];
-              deduped_6_2 := hoisted_28_1[deduped_10_2];
-              deduped_5_2 := deduped_12_1[1 + deduped_6_2];
-              deduped_4_2 := 1 + deduped_5_2;
-              if IdFunc( function (  )
-                          if deduped_6_2 = deduped_13_1[deduped_4_2] and deduped_7_2 = deduped_15_1[deduped_4_2] then
-                              return deduped_8_2 = deduped_5_2;
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_9_2, [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_2 )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_9_2, deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_3 )
-                             if IndexOfObject( Source( mor_3 ) ) = deduped_6_2 and IndexOfObject( Range( mor_3 ) ) = deduped_7_2 then
-                                 return IndexOfMorphism( mor_3 ) = deduped_8_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
-          end ) );
-    deduped_6_1 := Concatenation( List( deduped_51_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_4_1[1 + j_2] - 1 ] ), deduped_47_1 );
-          end ) );
-    hoisted_33_1 := List( deduped_46_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_31_1[deduped_3_2];
-            hoisted_1_2 := hoisted_32_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
+    deduped_24_1 := List( IndicesOfGeneratingMorphisms( deduped_68_1 ), function ( i_2 )
+            return deduped_16_1[1 + i_2];
         end );
-    deduped_11_1 := Concatenation( List( deduped_50_1, function ( i_2 )
-              return ListWithIdenticalEntries( deduped_1_1[1 + i_2], i_2 );
-          end ) );
-    deduped_8_1 := List( deduped_61_1, AsList );
-    hoisted_25_1 := Concatenation( List( deduped_51_1, function ( j_2 )
+    deduped_34_1 := List( deduped_57_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_4_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_24_1[deduped_2_2] ) );
+        end );
+    hoisted_37_1 := Concatenation( List( deduped_57_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      return deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)] )];
-                  end );
-          end ) );
-    deduped_26_1 := List( deduped_46_1, function ( j_2 )
-            return Product( hoisted_25_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_23_1 := Concatenation( List( deduped_51_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_35_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_34_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_48_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_48_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_45_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_54_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_54_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_51_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_20_1 := Concatenation( List( deduped_51_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_4_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3;
-                      deduped_9_3 := deduped_12_1[1 + deduped_11_1[(1 + (hoisted_1_2[1 + i_3] + hoisted_2_2))]];
-                      deduped_8_3 := 1 + deduped_9_3;
-                      deduped_7_3 := deduped_15_1[deduped_8_3];
-                      deduped_6_3 := deduped_13_1[deduped_8_3];
-                      deduped_5_3 := deduped_12_1[1 + deduped_6_3];
+    deduped_25_1 := List( deduped_70_1[2], AsList );
+    deduped_23_1 := List( deduped_55_1, function ( i_2 )
+            return deduped_14_1[1 + i_2];
+        end );
+    deduped_22_1 := List( deduped_55_1, function ( i_2 )
+            return deduped_11_1[1 + i_2];
+        end );
+    deduped_18_1 := deduped_61_1[4];
+    hoisted_36_1 := Concatenation( List( deduped_57_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_34_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_35_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
                       deduped_4_3 := 1 + deduped_5_3;
                       if IdFunc( function (  )
-                                  if deduped_6_3 = deduped_13_1[deduped_4_3] and deduped_7_3 = deduped_15_1[deduped_4_3] then
-                                      return deduped_9_3 = deduped_5_3;
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
                                   else
                                       return false;
                                   fi;
                                   return;
                               end )(  ) then
-                          return [ 0 .. deduped_3_1[SafeUniquePosition( deduped_2_1, deduped_6_3 )] - 1 ];
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
                       else
-                          return deduped_19_1[SafeUniquePositionProperty( deduped_18_1, function ( mor_4 )
-                                   if IndexOfObject( Source( mor_4 ) ) = deduped_6_3 and IndexOfObject( Range( mor_4 ) ) = deduped_7_3 then
-                                       return IndexOfMorphism( mor_4 ) = deduped_9_3;
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
                                    else
                                        return false;
                                    fi;
@@ -1235,50 +1421,142 @@ function ( cat_1, arg2_1, arg3_1 )
                       return;
                   end );
           end ) );
-    hoisted_24_1 := List( deduped_46_1, function ( i_2 )
+    deduped_10_1 := Concatenation( List( deduped_57_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_53_1 );
+          end ) );
+    hoisted_38_1 := List( deduped_52_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_20_1[deduped_3_2];
-            hoisted_1_2 := hoisted_23_1[deduped_3_2];
-            return List( [ 0 .. deduped_6_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_36_1[deduped_3_2];
+            hoisted_1_2 := hoisted_37_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_44_1 := Filtered( deduped_45_1, function ( x_2 )
+    hoisted_31_1 := Concatenation( List( deduped_57_1, function ( m_2 )
+              local deduped_1_2;
+              deduped_1_2 := 1 + m_2;
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_4_1[deduped_1_2]], deduped_2_1[1 + deduped_6_1[deduped_1_2]] );
+          end ) );
+    deduped_32_1 := List( deduped_50_1, function ( j_2 )
+            return Product( hoisted_31_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_21_1 := List( deduped_57_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_19_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_19_1[deduped_2_2] - 1 ], List( deduped_20_1[deduped_2_2][2], function ( objC_3 )
+                      return deduped_16_1[1 + deduped_15_1[(1 + IndexOfObject( objC_3 ))]];
+                  end ) );
+        end );
+    hoisted_13_1 := List( deduped_67_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_12_1 := List( deduped_67_1, AsList );
+    deduped_17_1 := List( deduped_57_1, function ( m_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + m_2;
+            return NTuple( 2, hoisted_12_1[deduped_1_2], ListWithIdenticalEntries( hoisted_13_1[deduped_1_2], deduped_16_1[1 + deduped_15_1[(1 + deduped_6_1[deduped_1_2])]] ) );
+        end );
+    hoisted_29_1 := Concatenation( List( deduped_57_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_21_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_17_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_54_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_54_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_51_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_26_1 := Concatenation( List( deduped_57_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, deduped_4_2, deduped_5_2;
+              deduped_5_2 := 1 + i_2;
+              deduped_4_2 := deduped_17_1[deduped_5_2];
+              hoisted_3_2 := List( deduped_21_1[deduped_5_2][2], IndexOfMorphism );
+              hoisted_2_2 := deduped_4_2[1];
+              hoisted_1_2 := List( deduped_4_2[2], IndexOfMorphism );
+              return List( [ 0 .. deduped_8_1[deduped_5_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3, deduped_9_3, deduped_10_3, deduped_11_3;
+                      deduped_11_3 := 1 + i_3;
+                      deduped_10_3 := deduped_18_1[1 + hoisted_1_2[deduped_11_3]][1 + hoisted_3_2[(1 + hoisted_2_2[deduped_11_3])]];
+                      deduped_9_3 := 1 + deduped_10_3;
+                      deduped_8_3 := deduped_23_1[deduped_9_3];
+                      deduped_7_3 := deduped_22_1[deduped_9_3];
+                      deduped_6_3 := 1 + deduped_7_3;
+                      deduped_5_3 := deduped_15_1[deduped_6_3];
+                      deduped_4_3 := 1 + deduped_5_3;
+                      if IdFunc( function (  )
+                                  if deduped_7_3 = deduped_22_1[deduped_4_3] and deduped_8_3 = deduped_23_1[deduped_4_3] then
+                                      return deduped_10_3 = deduped_5_3;
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_2_1[deduped_6_3] - 1 ];
+                      else
+                          return deduped_25_1[SafeUniquePositionProperty( deduped_24_1, function ( mor_4 )
+                                   if IndexOfObject( Source( mor_4 ) ) = deduped_7_3 and IndexOfObject( Range( mor_4 ) ) = deduped_8_3 then
+                                       return IndexOfMorphism( mor_4 ) = deduped_10_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_30_1 := List( deduped_52_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_26_1[deduped_3_2];
+            hoisted_1_2 := hoisted_29_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    deduped_49_1 := Filtered( deduped_51_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_46_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_50_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_24_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_46_1, function ( j_3 )
+                        return hoisted_30_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_50_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_33_1[deduped_1_3][deduped_1_2] * deduped_26_1[deduped_1_3];
+                        return hoisted_38_1[deduped_1_3][deduped_1_2] * deduped_32_1[deduped_1_3];
                     end ) );
         end );
-    deduped_43_1 := Length( deduped_44_1 );
-    hoisted_41_1 := Range( cat_1 );
-    deduped_36_1 := List( deduped_56_1, Length );
-    deduped_37_1 := List( deduped_52_1, function ( i_2 )
-            return Product( deduped_48_1{[ 1 + Sum( deduped_36_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_36_1{[ 1 .. i_2 ]} ) ]} );
+    deduped_48_1 := Length( deduped_49_1 );
+    hoisted_46_1 := Range( cat_1 );
+    deduped_41_1 := List( deduped_62_1, Length );
+    deduped_42_1 := List( deduped_58_1, function ( i_2 )
+            return Product( deduped_54_1{[ 1 + Sum( deduped_41_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_41_1{[ 1 .. i_2 ]} ) ]} );
         end );
-    hoisted_38_1 := List( deduped_52_1, function ( i_2 )
+    hoisted_43_1 := List( deduped_58_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2;
-            hoisted_2_2 := deduped_37_1[i_2];
-            hoisted_1_2 := Product( deduped_37_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_45_1, function ( i_3 )
+            hoisted_2_2 := deduped_42_1[i_2];
+            hoisted_1_2 := Product( deduped_42_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_51_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    return List( [ 0 .. deduped_43_1 - 1 ], function ( i_2 )
+    return List( [ 0 .. deduped_48_1 - 1 ], function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := 1 + deduped_44_1[(1 + REM_INT( i_2, deduped_43_1 ))];
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, List( deduped_52_1, function ( i_3 )
+            hoisted_1_2 := 1 + deduped_49_1[(1 + REM_INT( i_2, deduped_48_1 ))];
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, List( deduped_58_1, function ( i_3 )
                       local deduped_1_3, hoisted_2_3;
-                      hoisted_2_3 := hoisted_38_1[i_3][hoisted_1_2];
-                      deduped_1_3 := deduped_3_1[i_3];
-                      return CreateCapCategoryMorphismWithAttributes( hoisted_41_1, deduped_56_1[i_3], deduped_60_1[i_3], AsList, List( [ 0 .. deduped_36_1[i_3] - 1 ], function ( i_4 )
+                      hoisted_2_3 := hoisted_43_1[i_3][hoisted_1_2];
+                      deduped_1_3 := deduped_2_1[i_3];
+                      return CreateCapCategoryMorphismWithAttributes( hoisted_46_1, deduped_62_1[i_3], deduped_65_1[i_3], AsList, List( [ 0 .. deduped_41_1[i_3] - 1 ], function ( i_4 )
                                 return REM_INT( QUO_INT( hoisted_2_3, deduped_1_3 ^ i_4 ), deduped_1_3 );
                             end ) );
                   end ) );

--- a/FunctorCategories/gap/precompiled_categories/PreSheavesOfFpCategoryInSkeletalFinSetsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/PreSheavesOfFpCategoryInSkeletalFinSetsPrecompiled.gi
@@ -117,179 +117,268 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, deduped_18_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, deduped_31_1, deduped_32_1, deduped_33_1, deduped_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1;
-    deduped_42_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_41_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_40_1 := Source( cat_1 );
-    deduped_39_1 := SetOfGeneratingMorphisms( deduped_40_1 );
-    deduped_38_1 := deduped_41_1[2];
-    deduped_37_1 := SetOfObjects( deduped_40_1 );
-    deduped_36_1 := DefiningTripleOfUnderlyingQuiver( deduped_40_1 );
-    deduped_35_1 := [ 0 .. deduped_36_1[2] - 1 ];
-    deduped_34_1 := [ 0 .. deduped_36_1[1] - 1 ];
-    deduped_5_1 := List( deduped_38_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, deduped_20_1, deduped_21_1, hoisted_22_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, deduped_28_1, deduped_30_1, deduped_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, deduped_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1;
+    deduped_47_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_46_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_45_1 := Source( cat_1 );
+    deduped_44_1 := deduped_46_1[2];
+    deduped_43_1 := SetOfObjects( deduped_45_1 );
+    deduped_42_1 := DefiningTripleOfUnderlyingQuiver( deduped_45_1 );
+    deduped_41_1 := [ 0 .. deduped_42_1[2] - 1 ];
+    deduped_40_1 := [ 0 .. deduped_42_1[1] - 1 ];
+    deduped_5_1 := deduped_42_1[3];
+    deduped_7_1 := List( deduped_41_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][1];
         end );
-    deduped_33_1 := [ 0 .. Sum( List( deduped_35_1, function ( j_2 )
-                    return deduped_5_1[1 + j_2];
+    deduped_6_1 := List( deduped_41_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][2];
+        end );
+    deduped_1_1 := List( deduped_46_1[1], Length );
+    deduped_8_1 := List( deduped_41_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_43_1[1 + deduped_7_1[deduped_2_2]] ) );
+        end );
+    deduped_39_1 := [ 0 .. Sum( List( deduped_41_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_4_1 := List( deduped_42_1[1], Length );
-    deduped_2_1 := List( deduped_37_1, UnderlyingVertex );
-    deduped_1_1 := List( deduped_41_1[1], Length );
-    deduped_32_1 := Concatenation( List( deduped_34_1, function ( i_2 )
+    deduped_4_1 := List( deduped_47_1[1], Length );
+    deduped_2_1 := List( deduped_43_1, UnderlyingVertex );
+    deduped_38_1 := Concatenation( List( deduped_40_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_37_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_43_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_31_1 := Product( deduped_32_1 );
-    deduped_30_1 := [ 0 .. deduped_31_1 - 1 ];
-    deduped_10_1 := List( deduped_34_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
+    deduped_37_1 := [ 0 .. Sum( List( deduped_41_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_5_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_36_1 := Product( deduped_38_1 );
+    deduped_35_1 := [ 0 .. deduped_36_1 - 1 ];
+    deduped_20_1 := SetOfGeneratingMorphisms( deduped_45_1 );
+    deduped_31_1 := List( deduped_41_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_20_1[deduped_2_2] ) );
+        end );
+    deduped_13_1 := UnderlyingQuiverAlgebra( deduped_45_1 );
+    deduped_12_1 := List( deduped_40_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_43_1[deduped_2_2] ) );
+        end );
+    deduped_11_1 := List( deduped_40_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
+        end );
+    deduped_30_1 := List( deduped_41_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_11_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_11_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_45_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
                   end ) );
         end );
-    deduped_9_1 := deduped_36_1[3];
-    hoisted_28_1 := Concatenation( List( deduped_35_1, function ( j_2 )
+    hoisted_33_1 := Concatenation( List( deduped_41_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_30_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_31_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_38_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_38_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_35_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    deduped_21_1 := List( deduped_47_1[2], AsList );
+    hoisted_32_1 := Concatenation( List( deduped_41_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_31_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_30_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_43_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    deduped_10_1 := Concatenation( List( deduped_41_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_36_1 );
+          end ) );
+    hoisted_34_1 := List( deduped_39_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_32_1[deduped_3_2];
+            hoisted_1_2 := hoisted_33_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_27_1 := Concatenation( List( deduped_41_1, function ( m_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_5_1[deduped_2_2] - 1 ], function ( i_3 )
+              deduped_2_2 := 1 + m_2;
+              hoisted_1_2 := deduped_2_1[1 + deduped_7_1[deduped_2_2]];
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_6_1[deduped_2_2]], deduped_4_1[SafeUniquePositionProperty( deduped_43_1, function ( obj_3 )
+                         return UnderlyingVertex( obj_3 ) = hoisted_1_2;
+                     end )] );
+          end ) );
+    deduped_28_1 := List( deduped_37_1, function ( j_2 )
+            return Product( hoisted_27_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_18_1 := List( deduped_43_1, function ( logic_new_func_x_2 )
+            return QuiverVertexAsIdentityPath( UnderlyingVertex( logic_new_func_x_2 ) );
+        end );
+    hoisted_17_1 := List( deduped_44_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_16_1 := List( deduped_44_1, AsList );
+    deduped_19_1 := List( deduped_41_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := 1 + m_2;
+            deduped_2_2 := 1 + deduped_7_1[deduped_3_2];
+            deduped_1_2 := deduped_43_1[deduped_2_2];
+            return NTuple( 2, hoisted_16_1[deduped_3_2], ListWithIdenticalEntries( hoisted_17_1[deduped_3_2], CreateCapCategoryMorphismWithAttributes( deduped_45_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, hoisted_18_1[deduped_2_2] ) ) ) );
+        end );
+    deduped_15_1 := List( deduped_41_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_7_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_11_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_11_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_45_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
+                  end ) );
+        end );
+    hoisted_25_1 := Concatenation( List( deduped_41_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_15_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_19_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_32_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_32_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_30_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_38_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_38_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_35_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_26_1 := List( deduped_42_1[2], AsList );
-    hoisted_24_1 := UnderlyingQuiverAlgebra( deduped_40_1 );
-    hoisted_23_1 := List( deduped_39_1, function ( logic_new_func_x_2 )
-            return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_2 ) ) );
-        end );
-    hoisted_22_1 := List( deduped_39_1, UnderlyingQuiverAlgebraElement );
-    hoisted_21_1 := List( deduped_39_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Source( logic_new_func_x_2 ) );
-        end );
-    hoisted_20_1 := List( deduped_39_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Range( logic_new_func_x_2 ) );
-        end );
-    hoisted_27_1 := Concatenation( List( deduped_35_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + j_2;
-              deduped_7_2 := deduped_5_1[deduped_8_2];
-              deduped_6_2 := hoisted_22_1[deduped_8_2];
-              deduped_5_2 := hoisted_21_1[deduped_8_2];
-              deduped_4_2 := hoisted_20_1[deduped_8_2];
-              if IdFunc( function (  )
-                          if deduped_4_2 = deduped_5_2 then
-                              return deduped_6_2 = PathAsAlgebraElement( hoisted_24_1, hoisted_23_1[deduped_8_2] );
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_7_2, [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_37_1, function ( obj_3 )
-                                   return (UnderlyingVertex( obj_3 ) = deduped_5_2);
-                               end )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_7_2, hoisted_26_1[SafeUniquePositionProperty( deduped_39_1, function ( mor_3 )
-                             if UnderlyingVertex( Source( mor_3 ) ) = deduped_5_2 and UnderlyingVertex( Range( mor_3 ) ) = deduped_4_2 then
-                                 return UnderlyingQuiverAlgebraElement( mor_3 ) = deduped_6_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
+    hoisted_22_1 := Concatenation( List( deduped_41_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_19_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_15_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_43_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    deduped_7_1 := Concatenation( List( deduped_35_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_5_1[1 + j_2] - 1 ] ), deduped_31_1 );
-          end ) );
-    hoisted_29_1 := List( deduped_33_1, function ( i_2 )
+    hoisted_26_1 := List( deduped_39_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_27_1[deduped_3_2];
-            hoisted_1_2 := hoisted_28_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_22_1[deduped_3_2];
+            hoisted_1_2 := hoisted_25_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_11_1 := Concatenation( List( deduped_34_1, function ( i_2 )
-              local deduped_1_2;
-              deduped_1_2 := 1 + i_2;
-              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
-          end ) );
-    deduped_8_1 := List( deduped_38_1, AsList );
-    hoisted_17_1 := Concatenation( List( deduped_35_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return deduped_4_1[SafeUniquePositionProperty( deduped_37_1, function ( obj_4 )
-                               return UnderlyingVertex( obj_4 ) = hoisted_1_3;
-                           end )];
-                  end );
-          end ) );
-    deduped_18_1 := List( deduped_33_1, function ( j_2 )
-            return Product( hoisted_17_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_15_1 := Concatenation( List( deduped_35_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_32_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_32_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_30_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_12_1 := Concatenation( List( deduped_35_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_37_1, function ( obj_4 )
-                                     return (UnderlyingVertex( obj_4 ) = hoisted_1_3);
-                                 end )] - 1 ];
-                  end );
-          end ) );
-    hoisted_16_1 := List( deduped_33_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_12_1[deduped_3_2];
-            hoisted_1_2 := hoisted_15_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    return CreateCapCategoryObjectWithAttributes( Range( cat_1 ), Length, Length( Filtered( deduped_30_1, function ( x_2 )
+    return CreateCapCategoryObjectWithAttributes( Range( cat_1 ), Length, Length( Filtered( deduped_35_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_33_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_37_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_33_1, function ( j_3 )
+                            return hoisted_26_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_37_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_29_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
+                            return hoisted_34_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
                         end ) );
             end ) ) );
 end
@@ -302,438 +391,660 @@ end
         
 ########
 function ( cat_1, source_1, alpha_1, beta_1, range_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, deduped_18_1, deduped_20_1, deduped_21_1, deduped_22_1, deduped_23_1, deduped_24_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_30_1, deduped_31_1, hoisted_32_1, hoisted_33_1, hoisted_36_1, hoisted_37_1, deduped_39_1, hoisted_41_1, hoisted_42_1, deduped_43_1, hoisted_47_1, hoisted_48_1, hoisted_49_1, hoisted_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, hoisted_56_1, hoisted_57_1, hoisted_58_1, hoisted_59_1, deduped_60_1, hoisted_62_1, hoisted_63_1, hoisted_64_1, hoisted_65_1, hoisted_66_1, hoisted_67_1, hoisted_68_1, deduped_69_1, deduped_70_1, deduped_71_1, deduped_72_1, deduped_73_1, deduped_74_1, deduped_75_1, deduped_76_1, deduped_77_1, deduped_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1;
-    deduped_94_1 := Source( cat_1 );
-    deduped_93_1 := ListOfValues( ValuesOnAllObjects( alpha_1 ) );
-    deduped_92_1 := ValuesOfPreSheaf( Source( beta_1 ) );
-    deduped_91_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
-    deduped_90_1 := SetOfGeneratingMorphisms( deduped_94_1 );
-    deduped_89_1 := DefiningTripleOfUnderlyingQuiver( deduped_94_1 );
-    deduped_88_1 := ValuesOfPreSheaf( Range( beta_1 ) );
-    deduped_87_1 := SetOfObjects( deduped_94_1 );
-    deduped_86_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
-    deduped_85_1 := deduped_91_1[2];
-    deduped_84_1 := deduped_86_1[2];
-    deduped_83_1 := [ 1 .. Length( deduped_93_1 ) ];
-    deduped_82_1 := [ 0 .. deduped_89_1[2] - 1 ];
-    deduped_81_1 := [ 0 .. deduped_89_1[1] - 1 ];
-    deduped_1_1 := List( deduped_86_1[1], Length );
-    deduped_80_1 := Sum( List( deduped_81_1, function ( i_2 )
-              return deduped_1_1[1 + i_2];
-          end ) );
-    deduped_51_1 := List( deduped_85_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_12_1, deduped_13_1, deduped_15_1, hoisted_16_1, hoisted_17_1, deduped_18_1, deduped_19_1, deduped_20_1, deduped_21_1, hoisted_22_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, deduped_28_1, deduped_30_1, deduped_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, deduped_35_1, deduped_36_1, hoisted_37_1, hoisted_38_1, hoisted_41_1, hoisted_42_1, hoisted_45_1, deduped_46_1, hoisted_47_1, hoisted_48_1, deduped_49_1, deduped_50_1, hoisted_51_1, deduped_52_1, hoisted_55_1, hoisted_56_1, hoisted_57_1, hoisted_58_1, deduped_59_1, deduped_60_1, deduped_61_1, hoisted_62_1, hoisted_63_1, deduped_64_1, hoisted_65_1, hoisted_66_1, hoisted_67_1, hoisted_68_1, deduped_69_1, deduped_71_1, deduped_72_1, hoisted_73_1, hoisted_74_1, hoisted_75_1, hoisted_76_1, hoisted_77_1, hoisted_78_1, deduped_79_1, deduped_80_1, deduped_81_1, deduped_82_1, deduped_83_1, deduped_84_1, deduped_85_1, deduped_86_1, deduped_87_1, deduped_88_1, deduped_89_1, deduped_90_1, deduped_91_1, deduped_92_1, deduped_93_1, deduped_94_1, deduped_95_1, deduped_96_1, deduped_97_1, deduped_98_1, deduped_99_1, deduped_100_1, deduped_101_1, deduped_102_1, deduped_103_1, deduped_104_1, deduped_105_1, deduped_106_1, deduped_107_1;
+    deduped_107_1 := Source( cat_1 );
+    deduped_106_1 := ListOfValues( ValuesOnAllObjects( alpha_1 ) );
+    deduped_105_1 := ValuesOfPreSheaf( Source( beta_1 ) );
+    deduped_104_1 := ValuesOfPreSheaf( Range( alpha_1 ) );
+    deduped_103_1 := DefiningTripleOfUnderlyingQuiver( deduped_107_1 );
+    deduped_102_1 := ValuesOfPreSheaf( Range( beta_1 ) );
+    deduped_101_1 := SetOfObjects( deduped_107_1 );
+    deduped_100_1 := ValuesOfPreSheaf( Source( alpha_1 ) );
+    deduped_99_1 := deduped_104_1[2];
+    deduped_98_1 := deduped_100_1[2];
+    deduped_97_1 := deduped_103_1[1];
+    deduped_96_1 := [ 1 .. deduped_97_1 ];
+    deduped_95_1 := [ 0 .. deduped_97_1 - 1 ];
+    deduped_94_1 := [ 0 .. deduped_103_1[2] - 1 ];
+    deduped_1_1 := List( deduped_100_1[1], Length );
+    deduped_93_1 := List( deduped_95_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
         end );
-    deduped_79_1 := [ 0 .. Sum( List( deduped_82_1, function ( j_2 )
-                    return deduped_51_1[1 + j_2];
-                end ) ) - 1 ];
-    deduped_78_1 := [ 0 .. deduped_80_1 - 1 ];
-    deduped_5_1 := List( deduped_84_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    deduped_92_1 := Sum( deduped_93_1 );
+    deduped_35_1 := List( deduped_104_1[1], Length );
+    deduped_5_1 := deduped_103_1[3];
+    deduped_7_1 := List( deduped_94_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][1];
         end );
-    deduped_77_1 := [ 0 .. Sum( List( deduped_82_1, function ( j_2 )
-                    return deduped_5_1[1 + j_2];
+    deduped_6_1 := List( deduped_94_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][2];
+        end );
+    deduped_59_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_35_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_101_1[1 + deduped_7_1[deduped_2_2]] ) );
+        end );
+    deduped_91_1 := [ 0 .. Sum( List( deduped_94_1, function ( i_2 )
+                    return deduped_59_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_31_1 := List( deduped_92_1[1], Length );
-    deduped_30_1 := List( deduped_91_1[1], Length );
-    deduped_2_1 := List( deduped_87_1, UnderlyingVertex );
-    deduped_76_1 := Concatenation( List( deduped_81_1, function ( i_2 )
+    deduped_90_1 := [ 0 .. deduped_92_1 - 1 ];
+    deduped_8_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_101_1[1 + deduped_7_1[deduped_2_2]] ) );
+        end );
+    deduped_89_1 := [ 0 .. Sum( List( deduped_94_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
+                end ) ) - 1 ];
+    deduped_36_1 := List( deduped_105_1[1], Length );
+    deduped_2_1 := List( deduped_101_1, UnderlyingVertex );
+    deduped_88_1 := Concatenation( List( deduped_95_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_30_1[deduped_2_2], deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_35_1[deduped_2_2], deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_75_1 := Concatenation( List( deduped_81_1, function ( i_2 )
+    deduped_87_1 := Concatenation( List( deduped_95_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_4_1 := List( deduped_88_1[1], Length );
-    deduped_74_1 := Concatenation( List( deduped_81_1, function ( i_2 )
+    deduped_4_1 := List( deduped_102_1[1], Length );
+    deduped_86_1 := Concatenation( List( deduped_95_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_73_1 := Product( deduped_76_1 );
-    deduped_72_1 := Product( deduped_74_1 );
-    deduped_71_1 := [ 0 .. deduped_73_1 - 1 ];
-    deduped_70_1 := [ 0 .. Product( deduped_75_1 ) - 1 ];
-    deduped_69_1 := [ 0 .. deduped_72_1 - 1 ];
-    deduped_10_1 := List( deduped_81_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
+    deduped_85_1 := [ 0 .. Sum( List( deduped_94_1, function ( m_2 )
+                    return deduped_35_1[1 + deduped_5_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_84_1 := [ 0 .. Sum( List( deduped_94_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_5_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_83_1 := Product( deduped_88_1 );
+    deduped_82_1 := Product( deduped_86_1 );
+    deduped_81_1 := [ 0 .. deduped_83_1 - 1 ];
+    deduped_80_1 := [ 0 .. Product( deduped_87_1 ) - 1 ];
+    deduped_79_1 := [ 0 .. deduped_82_1 - 1 ];
+    deduped_20_1 := SetOfGeneratingMorphisms( deduped_107_1 );
+    deduped_31_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_20_1[deduped_2_2] ) );
+        end );
+    deduped_13_1 := UnderlyingQuiverAlgebra( deduped_107_1 );
+    deduped_12_1 := List( deduped_95_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_101_1[deduped_2_2] ) );
+        end );
+    deduped_30_1 := List( deduped_94_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_93_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_93_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_107_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
                   end ) );
         end );
-    deduped_9_1 := deduped_89_1[3];
-    hoisted_28_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_5_1[deduped_2_2] - 1 ], function ( i_3 )
+    hoisted_33_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_30_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_31_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_74_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_74_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_69_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_86_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_86_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_79_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_26_1 := List( deduped_88_1[2], AsList );
-    deduped_24_1 := UnderlyingQuiverAlgebra( deduped_94_1 );
-    deduped_23_1 := List( deduped_90_1, function ( logic_new_func_x_2 )
-            return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_2 ) ) );
-        end );
-    deduped_22_1 := List( deduped_90_1, UnderlyingQuiverAlgebraElement );
-    deduped_21_1 := List( deduped_90_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Source( logic_new_func_x_2 ) );
-        end );
-    deduped_20_1 := List( deduped_90_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Range( logic_new_func_x_2 ) );
-        end );
-    hoisted_27_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + j_2;
-              deduped_7_2 := deduped_5_1[deduped_8_2];
-              deduped_6_2 := deduped_22_1[deduped_8_2];
-              deduped_5_2 := deduped_21_1[deduped_8_2];
-              deduped_4_2 := deduped_20_1[deduped_8_2];
-              if IdFunc( function (  )
-                          if deduped_4_2 = deduped_5_2 then
-                              return deduped_6_2 = PathAsAlgebraElement( deduped_24_1, deduped_23_1[deduped_8_2] );
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_7_2, [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
-                                   return (UnderlyingVertex( obj_3 ) = deduped_5_2);
-                               end )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_7_2, hoisted_26_1[SafeUniquePositionProperty( deduped_90_1, function ( mor_3 )
-                             if UnderlyingVertex( Source( mor_3 ) ) = deduped_5_2 and UnderlyingVertex( Range( mor_3 ) ) = deduped_4_2 then
-                                 return UnderlyingQuiverAlgebraElement( mor_3 ) = deduped_6_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
+    deduped_21_1 := List( deduped_102_1[2], AsList );
+    hoisted_32_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_31_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_30_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    deduped_7_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_5_1[1 + j_2] - 1 ] ), deduped_72_1 );
+    deduped_10_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_82_1 );
           end ) );
-    hoisted_29_1 := List( deduped_77_1, function ( i_2 )
+    hoisted_34_1 := List( deduped_89_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_27_1[deduped_3_2];
-            hoisted_1_2 := hoisted_28_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_32_1[deduped_3_2];
+            hoisted_1_2 := hoisted_33_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_11_1 := Concatenation( List( deduped_81_1, function ( i_2 )
-              local deduped_1_2;
-              deduped_1_2 := 1 + i_2;
-              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
-          end ) );
-    deduped_8_1 := List( deduped_84_1, AsList );
-    hoisted_17_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return deduped_4_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_4 )
-                               return UnderlyingVertex( obj_4 ) = hoisted_1_3;
-                           end )];
-                  end );
-          end ) );
-    deduped_18_1 := List( deduped_77_1, function ( j_2 )
-            return Product( hoisted_17_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_15_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_74_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_74_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_69_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_12_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_4 )
-                                     return (UnderlyingVertex( obj_4 ) = hoisted_1_3);
-                                 end )] - 1 ];
-                  end );
-          end ) );
-    hoisted_16_1 := List( deduped_77_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_12_1[deduped_3_2];
-            hoisted_1_2 := hoisted_15_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    hoisted_68_1 := Filtered( deduped_69_1, function ( x_2 )
-            local deduped_1_2;
-            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_77_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_77_1, function ( j_3 )
-                        local deduped_1_3;
-                        deduped_1_3 := 1 + j_3;
-                        return hoisted_29_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
-                    end ) );
-        end );
-    hoisted_37_1 := List( deduped_78_1, function ( j_2 )
-            return Product( deduped_74_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_32_1 := List( ValuesOnAllObjects( beta_1 ), AsList );
-    hoisted_33_1 := Concatenation( List( deduped_81_1, function ( i_2 )
+    hoisted_27_1 := Concatenation( List( deduped_94_1, function ( m_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
-              hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], hoisted_32_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
+              deduped_2_2 := 1 + m_2;
+              hoisted_1_2 := deduped_2_1[1 + deduped_7_1[deduped_2_2]];
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_6_1[deduped_2_2]], deduped_4_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    hoisted_36_1 := List( [ 1 .. deduped_80_1 ], function ( i_2 )
+    deduped_28_1 := List( deduped_84_1, function ( j_2 )
+            return Product( hoisted_27_1{[ 1 .. j_2 ]} );
+        end );
+    deduped_18_1 := List( deduped_101_1, function ( logic_new_func_x_2 )
+            return QuiverVertexAsIdentityPath( UnderlyingVertex( logic_new_func_x_2 ) );
+        end );
+    hoisted_17_1 := List( deduped_98_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_16_1 := List( deduped_98_1, AsList );
+    deduped_19_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := 1 + m_2;
+            deduped_2_2 := 1 + deduped_7_1[deduped_3_2];
+            deduped_1_2 := deduped_101_1[deduped_2_2];
+            return NTuple( 2, hoisted_16_1[deduped_3_2], ListWithIdenticalEntries( hoisted_17_1[deduped_3_2], CreateCapCategoryMorphismWithAttributes( deduped_107_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, deduped_18_1[deduped_2_2] ) ) ) );
+        end );
+    deduped_15_1 := List( deduped_94_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_7_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_93_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_93_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_107_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
+                  end ) );
+        end );
+    hoisted_25_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_15_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_19_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_86_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_86_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_79_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_22_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_19_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_15_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    hoisted_26_1 := List( deduped_89_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_22_1[deduped_3_2];
+            hoisted_1_2 := hoisted_25_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_78_1 := Filtered( deduped_79_1, function ( x_2 )
+            local deduped_1_2;
+            deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_84_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_26_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_84_1, function ( j_3 )
+                        local deduped_1_3;
+                        deduped_1_3 := 1 + j_3;
+                        return hoisted_34_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
+                    end ) );
+        end );
+    hoisted_42_1 := List( deduped_90_1, function ( j_2 )
+            return Product( deduped_86_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_37_1 := List( ValuesOnAllObjects( beta_1 ), AsList );
+    hoisted_38_1 := Concatenation( List( deduped_95_1, function ( o_2 )
+              local hoisted_1_2, deduped_2_2;
+              deduped_2_2 := 1 + o_2;
+              hoisted_1_2 := deduped_2_1[deduped_2_2];
+              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], hoisted_37_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
+                         return UnderlyingVertex( obj_3 ) = hoisted_1_2;
+                     end )] );
+          end ) );
+    hoisted_41_1 := List( [ 1 .. deduped_92_1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, hoisted_3_2;
-            hoisted_3_2 := hoisted_33_1[i_2];
-            hoisted_2_2 := deduped_75_1[i_2];
-            hoisted_1_2 := Product( deduped_75_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_70_1, function ( i_3 )
+            hoisted_3_2 := hoisted_38_1[i_2];
+            hoisted_2_2 := deduped_87_1[i_2];
+            hoisted_1_2 := Product( deduped_87_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_80_1, function ( i_3 )
                     return hoisted_3_2[1 + REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 )];
                 end );
         end );
-    hoisted_50_1 := List( deduped_70_1, function ( i_2 )
+    hoisted_58_1 := List( deduped_80_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := 1 + i_2;
-            return Sum( deduped_78_1, function ( j_3 )
+            return Sum( deduped_90_1, function ( j_3 )
                     local deduped_1_3;
                     deduped_1_3 := 1 + j_3;
-                    return hoisted_36_1[deduped_1_3][hoisted_1_2] * hoisted_37_1[deduped_1_3];
+                    return hoisted_41_1[deduped_1_3][hoisted_1_2] * hoisted_42_1[deduped_1_3];
                 end );
         end );
-    hoisted_49_1 := List( deduped_78_1, function ( j_2 )
-            return Product( deduped_75_1{[ 1 .. j_2 ]} );
+    hoisted_57_1 := List( deduped_90_1, function ( j_2 )
+            return Product( deduped_87_1{[ 1 .. j_2 ]} );
         end );
-    deduped_43_1 := List( deduped_93_1, function ( logic_new_func_x_2 )
-            return Length( Range( logic_new_func_x_2 ) );
+    deduped_52_1 := List( deduped_95_1, function ( o_2 )
+            return deduped_35_1[1 + o_2];
         end );
-    deduped_39_1 := List( deduped_93_1, function ( logic_new_func_x_2 )
+    hoisted_48_1 := List( deduped_106_1, function ( logic_new_func_x_2 )
             return Length( Source( logic_new_func_x_2 ) );
         end );
-    hoisted_47_1 := Concatenation( List( deduped_83_1, function ( i_2 )
+    hoisted_47_1 := List( deduped_106_1, AsList );
+    deduped_49_1 := List( deduped_95_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_101_1[deduped_2_2];
+            return NTuple( 2, hoisted_47_1[deduped_2_2], ListWithIdenticalEntries( hoisted_48_1[deduped_2_2], CreateCapCategoryMorphismWithAttributes( deduped_107_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, deduped_18_1[deduped_2_2] ) ) ) );
+        end );
+    hoisted_55_1 := Concatenation( List( deduped_96_1, function ( i_2 )
               local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := Sum( deduped_43_1{[ 1 .. i_2 - 1 ]} );
-              hoisted_2_2 := [ deduped_3_2 .. deduped_3_2 + deduped_43_1[i_2] - 1 ];
-              hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( AsList( CAP_JIT_INCOMPLETE_LOGIC( deduped_93_1[i_2] ) ) );
-              return List( [ 0 .. deduped_39_1[i_2] - 1 ], function ( i_3 )
+              deduped_3_2 := Sum( deduped_52_1{[ 1 .. i_2 - 1 ]} );
+              hoisted_2_2 := [ deduped_3_2 .. deduped_3_2 + deduped_52_1[i_2] - 1 ];
+              hoisted_1_2 := deduped_49_1[i_2][1];
+              return List( [ 0 .. deduped_12_1[i_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + hoisted_2_2[(1 + hoisted_1_2[(1 + i_3)])];
-                      hoisted_2_3 := deduped_76_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_76_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_71_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_88_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_88_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_81_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_42_1 := Concatenation( List( deduped_81_1, function ( i_2 )
-              local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
-              hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], [ 0 .. deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
-                               return (UnderlyingVertex( obj_3 ) = hoisted_1_2);
-                           end )] - 1 ] );
+    deduped_50_1 := List( deduped_105_1[2], AsList );
+    deduped_46_1 := List( deduped_95_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_35_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_101_1[deduped_2_2] ) );
+        end );
+    hoisted_51_1 := Concatenation( List( deduped_96_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2;
+              deduped_9_2 := deduped_49_1[i_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_46_1[i_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, function ( objC_3 )
+                      return PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) );
+                  end );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, UnderlyingVertex );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_12_1[i_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_50_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    hoisted_41_1 := Concatenation( List( deduped_83_1, function ( i_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_39_1[i_2] - 1 ] ), deduped_73_1 );
+    hoisted_45_1 := Concatenation( List( deduped_96_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_12_1[i_2][1], deduped_83_1 );
           end ) );
-    hoisted_48_1 := List( [ 0 .. Sum( List( deduped_83_1, function ( i_2 )
-                      return Length( [ 0 .. deduped_39_1[i_2] - 1 ] );
+    hoisted_56_1 := List( [ 0 .. Sum( List( deduped_96_1, function ( i_2 )
+                      return deduped_12_1[i_2][1];
                   end ) ) - 1 ], function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_42_1[deduped_3_2];
-            hoisted_1_2 := hoisted_47_1[deduped_3_2];
-            return List( [ 0 .. hoisted_41_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_51_1[deduped_3_2];
+            hoisted_1_2 := hoisted_55_1[deduped_3_2];
+            return List( [ 0 .. hoisted_45_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    hoisted_67_1 := List( deduped_71_1, function ( i_2 )
+    hoisted_77_1 := List( deduped_81_1, function ( i_2 )
             local hoisted_1_2;
             hoisted_1_2 := 1 + i_2;
-            return hoisted_50_1[1 + Sum( deduped_78_1, function ( j_3 )
+            return hoisted_58_1[1 + Sum( deduped_90_1, function ( j_3 )
                        local deduped_1_3;
                        deduped_1_3 := (1 + j_3);
-                       return hoisted_48_1[deduped_1_3][hoisted_1_2] * hoisted_49_1[deduped_1_3];
+                       return hoisted_56_1[deduped_1_3][hoisted_1_2] * hoisted_57_1[deduped_1_3];
                    end )];
         end );
-    deduped_54_1 := List( deduped_81_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_30_1[j_3];
+    deduped_72_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_35_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_20_1[deduped_2_2] ) );
+        end );
+    deduped_71_1 := List( deduped_94_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_52_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_52_1[deduped_2_2] - 1 ], List( deduped_46_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_107_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
                   end ) );
         end );
-    hoisted_64_1 := Concatenation( List( deduped_82_1, function ( j_2 )
+    hoisted_74_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_71_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_72_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_59_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_88_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_88_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_81_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    hoisted_73_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_72_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_71_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_59_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_50_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    deduped_60_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_59_1[1 + i_2][1], deduped_83_1 );
+          end ) );
+    hoisted_75_1 := List( deduped_91_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_73_1[deduped_3_2];
+            hoisted_1_2 := hoisted_74_1[deduped_3_2];
+            return List( [ 0 .. deduped_60_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_68_1 := Concatenation( List( deduped_94_1, function ( m_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_54_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_51_1[deduped_2_2] - 1 ], function ( i_3 )
+              deduped_2_2 := 1 + m_2;
+              hoisted_1_2 := deduped_2_1[1 + deduped_7_1[deduped_2_2]];
+              return ListWithIdenticalEntries( deduped_35_1[1 + deduped_6_1[deduped_2_2]], deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_3 )
+                         return UnderlyingVertex( obj_3 ) = hoisted_1_2;
+                     end )] );
+          end ) );
+    deduped_69_1 := List( deduped_85_1, function ( j_2 )
+            return Product( hoisted_68_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_63_1 := List( deduped_99_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_62_1 := List( deduped_99_1, AsList );
+    deduped_64_1 := List( deduped_94_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := 1 + m_2;
+            deduped_2_2 := 1 + deduped_7_1[deduped_3_2];
+            deduped_1_2 := deduped_101_1[deduped_2_2];
+            return NTuple( 2, hoisted_62_1[deduped_3_2], ListWithIdenticalEntries( hoisted_63_1[deduped_3_2], CreateCapCategoryMorphismWithAttributes( deduped_107_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, deduped_18_1[deduped_2_2] ) ) ) );
+        end );
+    deduped_61_1 := List( deduped_94_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_7_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_52_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_52_1[deduped_2_2] - 1 ], List( deduped_46_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_107_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
+                  end ) );
+        end );
+    hoisted_66_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_61_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_64_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_59_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_76_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_76_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_71_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_88_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_88_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_81_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_62_1 := List( deduped_92_1[2], AsList );
-    hoisted_63_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + j_2;
-              deduped_7_2 := deduped_51_1[deduped_8_2];
-              deduped_6_2 := deduped_22_1[deduped_8_2];
-              deduped_5_2 := deduped_21_1[deduped_8_2];
-              deduped_4_2 := deduped_20_1[deduped_8_2];
-              if IdFunc( function (  )
-                          if deduped_4_2 = deduped_5_2 then
-                              return deduped_6_2 = PathAsAlgebraElement( deduped_24_1, deduped_23_1[deduped_8_2] );
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_7_2, [ 0 .. deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_3 )
-                                   return (UnderlyingVertex( obj_3 ) = deduped_5_2);
-                               end )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_7_2, hoisted_62_1[SafeUniquePositionProperty( deduped_90_1, function ( mor_3 )
-                             if UnderlyingVertex( Source( mor_3 ) ) = deduped_5_2 and UnderlyingVertex( Range( mor_3 ) ) = deduped_4_2 then
-                                 return UnderlyingQuiverAlgebraElement( mor_3 ) = deduped_6_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
+    hoisted_65_1 := Concatenation( List( deduped_94_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_64_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_61_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_59_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_36_1[SafeUniquePositionProperty( deduped_101_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_50_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    deduped_52_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_51_1[1 + j_2] - 1 ] ), deduped_73_1 );
-          end ) );
-    hoisted_65_1 := List( deduped_79_1, function ( i_2 )
+    hoisted_67_1 := List( deduped_91_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_63_1[deduped_3_2];
-            hoisted_1_2 := hoisted_64_1[deduped_3_2];
-            return List( [ 0 .. deduped_52_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_65_1[deduped_3_2];
+            hoisted_1_2 := hoisted_66_1[deduped_3_2];
+            return List( [ 0 .. deduped_60_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_55_1 := Concatenation( List( deduped_81_1, function ( i_2 )
-              local deduped_1_2;
-              deduped_1_2 := 1 + i_2;
-              return ListWithIdenticalEntries( deduped_30_1[deduped_1_2], deduped_2_1[deduped_1_2] );
-          end ) );
-    deduped_53_1 := List( deduped_85_1, AsList );
-    hoisted_59_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_54_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_53_1[deduped_3_2];
-              return List( [ 0 .. deduped_51_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_55_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_4 )
-                               return UnderlyingVertex( obj_4 ) = hoisted_1_3;
-                           end )];
-                  end );
-          end ) );
-    deduped_60_1 := List( deduped_79_1, function ( j_2 )
-            return Product( hoisted_59_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_57_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_54_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_53_1[deduped_3_2];
-              return List( [ 0 .. deduped_51_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_76_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_76_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_71_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_56_1 := Concatenation( List( deduped_82_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_54_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_53_1[deduped_3_2];
-              return List( [ 0 .. deduped_51_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_55_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return [ 0 .. deduped_31_1[SafeUniquePositionProperty( deduped_87_1, function ( obj_4 )
-                                     return (UnderlyingVertex( obj_4 ) = hoisted_1_3);
-                                 end )] - 1 ];
-                  end );
-          end ) );
-    hoisted_58_1 := List( deduped_79_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_56_1[deduped_3_2];
-            hoisted_1_2 := hoisted_57_1[deduped_3_2];
-            return List( [ 0 .. deduped_52_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    hoisted_66_1 := Filtered( deduped_71_1, function ( x_2 )
+    hoisted_76_1 := Filtered( deduped_81_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_79_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_85_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_58_1[deduped_1_3][deduped_1_2] * deduped_60_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_79_1, function ( j_3 )
+                        return hoisted_67_1[deduped_1_3][deduped_1_2] * deduped_69_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_85_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_65_1[deduped_1_3][deduped_1_2] * deduped_60_1[deduped_1_3];
+                        return hoisted_75_1[deduped_1_3][deduped_1_2] * deduped_69_1[deduped_1_3];
                     end ) );
         end );
     return CreateCapCategoryMorphismWithAttributes( Range( cat_1 ), source_1, range_1, AsList, List( [ 0 .. Length( source_1 ) - 1 ], function ( x_2 )
-              return -1 + BigInt( SafePosition( hoisted_68_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_67_1[(1 + hoisted_66_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))])] ) ) );
+              return -1 + BigInt( SafePosition( hoisted_78_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_77_1[(1 + hoisted_76_1[(1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 ))])] ) ) );
           end ) );
 end
 ########
@@ -745,197 +1056,286 @@ end
         
 ########
 function ( cat_1, source_1, range_1, alpha_1 )
-    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_14_1, hoisted_15_1, hoisted_18_1, hoisted_19_1, hoisted_20_1, deduped_21_1, hoisted_23_1, hoisted_24_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, hoisted_29_1, hoisted_30_1, hoisted_31_1, hoisted_32_1, deduped_33_1, hoisted_34_1, hoisted_35_1, deduped_36_1, deduped_37_1, deduped_38_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1;
-    deduped_53_1 := ValuesOfPreSheaf( range_1 );
-    deduped_52_1 := ValuesOfPreSheaf( source_1 );
-    deduped_51_1 := Source( cat_1 );
-    deduped_50_1 := SetOfGeneratingMorphisms( deduped_51_1 );
-    deduped_49_1 := deduped_52_1[2];
-    deduped_48_1 := SetOfObjects( deduped_51_1 );
-    deduped_47_1 := deduped_53_1[1];
-    deduped_46_1 := deduped_52_1[1];
-    deduped_45_1 := DefiningTripleOfUnderlyingQuiver( deduped_51_1 );
-    deduped_44_1 := ListOfValues( deduped_46_1 );
-    deduped_43_1 := deduped_45_1[1];
-    deduped_42_1 := [ 1 .. deduped_43_1 ];
-    deduped_41_1 := [ 0 .. deduped_45_1[2] - 1 ];
-    deduped_40_1 := [ 0 .. deduped_43_1 - 1 ];
-    deduped_8_1 := List( deduped_49_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    local deduped_3_1, deduped_4_1, deduped_5_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, deduped_13_1, deduped_14_1, deduped_15_1, deduped_16_1, deduped_18_1, hoisted_19_1, hoisted_20_1, hoisted_21_1, deduped_22_1, deduped_23_1, deduped_24_1, hoisted_25_1, hoisted_28_1, hoisted_29_1, hoisted_30_1, deduped_31_1, deduped_33_1, deduped_34_1, hoisted_35_1, hoisted_36_1, hoisted_37_1, deduped_38_1, hoisted_39_1, hoisted_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1;
+    deduped_58_1 := ValuesOfPreSheaf( range_1 );
+    deduped_57_1 := ValuesOfPreSheaf( source_1 );
+    deduped_56_1 := Source( cat_1 );
+    deduped_55_1 := deduped_57_1[2];
+    deduped_54_1 := SetOfObjects( deduped_56_1 );
+    deduped_53_1 := deduped_58_1[1];
+    deduped_52_1 := deduped_57_1[1];
+    deduped_51_1 := DefiningTripleOfUnderlyingQuiver( deduped_56_1 );
+    deduped_50_1 := ListOfValues( deduped_52_1 );
+    deduped_49_1 := deduped_51_1[1];
+    deduped_48_1 := [ 1 .. deduped_49_1 ];
+    deduped_47_1 := [ 0 .. deduped_49_1 - 1 ];
+    deduped_46_1 := [ 0 .. deduped_51_1[2] - 1 ];
+    deduped_8_1 := deduped_51_1[3];
+    deduped_10_1 := List( deduped_46_1, function ( m_2 )
+            return deduped_8_1[1 + m_2][1];
         end );
-    deduped_39_1 := [ 0 .. Sum( List( deduped_41_1, function ( j_2 )
-                    return deduped_8_1[1 + j_2];
+    deduped_9_1 := List( deduped_46_1, function ( m_2 )
+            return deduped_8_1[1 + m_2][2];
+        end );
+    deduped_4_1 := List( deduped_52_1, Length );
+    deduped_11_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_4_1[1 + deduped_9_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_54_1[1 + deduped_10_1[deduped_2_2]] ) );
+        end );
+    deduped_45_1 := [ 0 .. Sum( List( deduped_46_1, function ( i_2 )
+                    return deduped_11_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_7_1 := List( deduped_47_1, Length );
-    deduped_5_1 := List( deduped_48_1, UnderlyingVertex );
-    deduped_4_1 := List( deduped_46_1, Length );
-    deduped_38_1 := Concatenation( List( deduped_40_1, function ( i_2 )
+    deduped_7_1 := List( deduped_53_1, Length );
+    deduped_5_1 := List( deduped_54_1, UnderlyingVertex );
+    deduped_44_1 := Concatenation( List( deduped_47_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_5_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_4_1[deduped_2_2], deduped_7_1[SafeUniquePositionProperty( deduped_48_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_4_1[deduped_2_2], deduped_7_1[SafeUniquePositionProperty( deduped_54_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_37_1 := Product( deduped_38_1 );
-    deduped_36_1 := [ 0 .. deduped_37_1 - 1 ];
-    hoisted_35_1 := Range( cat_1 );
-    deduped_13_1 := List( deduped_40_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_4_1[j_3];
+    deduped_43_1 := [ 0 .. Sum( List( deduped_46_1, function ( m_2 )
+                    return deduped_4_1[1 + deduped_8_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_42_1 := Product( deduped_44_1 );
+    deduped_41_1 := [ 0 .. deduped_42_1 - 1 ];
+    hoisted_40_1 := Range( cat_1 );
+    deduped_23_1 := SetOfGeneratingMorphisms( deduped_56_1 );
+    deduped_34_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_4_1[1 + deduped_9_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_23_1[deduped_2_2] ) );
+        end );
+    deduped_16_1 := UnderlyingQuiverAlgebra( deduped_56_1 );
+    deduped_15_1 := List( deduped_47_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_4_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_54_1[deduped_2_2] ) );
+        end );
+    deduped_14_1 := List( deduped_47_1, function ( o_2 )
+            return deduped_4_1[1 + o_2];
+        end );
+    deduped_33_1 := List( deduped_46_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_9_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_14_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_14_1[deduped_2_2] - 1 ], List( deduped_15_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_56_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_16_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
                   end ) );
         end );
-    deduped_12_1 := deduped_45_1[3];
-    hoisted_31_1 := Concatenation( List( deduped_41_1, function ( j_2 )
+    hoisted_36_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_33_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_34_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_11_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_44_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_44_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_41_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    deduped_24_1 := List( deduped_58_1[2], AsList );
+    hoisted_35_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_34_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_33_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_11_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_16_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_7_1[SafeUniquePositionProperty( deduped_54_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_24_1[SafeUniquePositionProperty( deduped_23_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    deduped_13_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_11_1[1 + i_2][1], deduped_42_1 );
+          end ) );
+    hoisted_37_1 := List( deduped_45_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_35_1[deduped_3_2];
+            hoisted_1_2 := hoisted_36_1[deduped_3_2];
+            return List( [ 0 .. deduped_13_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_30_1 := Concatenation( List( deduped_46_1, function ( m_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_13_1[1 + deduped_12_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_8_1[deduped_2_2] - 1 ], function ( i_3 )
+              deduped_2_2 := 1 + m_2;
+              hoisted_1_2 := deduped_5_1[1 + deduped_10_1[deduped_2_2]];
+              return ListWithIdenticalEntries( deduped_4_1[1 + deduped_9_1[deduped_2_2]], deduped_7_1[SafeUniquePositionProperty( deduped_54_1, function ( obj_3 )
+                         return UnderlyingVertex( obj_3 ) = hoisted_1_2;
+                     end )] );
+          end ) );
+    deduped_31_1 := List( deduped_43_1, function ( j_2 )
+            return Product( hoisted_30_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_21_1 := List( deduped_54_1, function ( logic_new_func_x_2 )
+            return QuiverVertexAsIdentityPath( UnderlyingVertex( logic_new_func_x_2 ) );
+        end );
+    hoisted_20_1 := List( deduped_55_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_19_1 := List( deduped_55_1, AsList );
+    deduped_22_1 := List( deduped_46_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := 1 + m_2;
+            deduped_2_2 := 1 + deduped_10_1[deduped_3_2];
+            deduped_1_2 := deduped_54_1[deduped_2_2];
+            return NTuple( 2, hoisted_19_1[deduped_3_2], ListWithIdenticalEntries( hoisted_20_1[deduped_3_2], CreateCapCategoryMorphismWithAttributes( deduped_56_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_16_1, hoisted_21_1[deduped_2_2] ) ) ) );
+        end );
+    deduped_18_1 := List( deduped_46_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_10_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_14_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_14_1[deduped_2_2] - 1 ], List( deduped_15_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_56_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_16_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
+                  end ) );
+        end );
+    hoisted_28_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_18_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_22_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_11_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_38_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_38_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_36_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_44_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_44_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_41_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_29_1 := List( deduped_53_1[2], AsList );
-    hoisted_27_1 := UnderlyingQuiverAlgebra( deduped_51_1 );
-    hoisted_26_1 := List( deduped_50_1, function ( logic_new_func_x_2 )
-            return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_2 ) ) );
-        end );
-    hoisted_25_1 := List( deduped_50_1, UnderlyingQuiverAlgebraElement );
-    hoisted_24_1 := List( deduped_50_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Source( logic_new_func_x_2 ) );
-        end );
-    hoisted_23_1 := List( deduped_50_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Range( logic_new_func_x_2 ) );
-        end );
-    hoisted_30_1 := Concatenation( List( deduped_41_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + j_2;
-              deduped_7_2 := deduped_8_1[deduped_8_2];
-              deduped_6_2 := hoisted_25_1[deduped_8_2];
-              deduped_5_2 := hoisted_24_1[deduped_8_2];
-              deduped_4_2 := hoisted_23_1[deduped_8_2];
-              if IdFunc( function (  )
-                          if deduped_4_2 = deduped_5_2 then
-                              return deduped_6_2 = PathAsAlgebraElement( hoisted_27_1, hoisted_26_1[deduped_8_2] );
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_7_2, [ 0 .. deduped_7_1[SafeUniquePositionProperty( deduped_48_1, function ( obj_3 )
-                                   return (UnderlyingVertex( obj_3 ) = deduped_5_2);
-                               end )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_7_2, hoisted_29_1[SafeUniquePositionProperty( deduped_50_1, function ( mor_3 )
-                             if UnderlyingVertex( Source( mor_3 ) ) = deduped_5_2 and UnderlyingVertex( Range( mor_3 ) ) = deduped_4_2 then
-                                 return UnderlyingQuiverAlgebraElement( mor_3 ) = deduped_6_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
+    hoisted_25_1 := Concatenation( List( deduped_46_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_22_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_18_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_11_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_16_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_7_1[SafeUniquePositionProperty( deduped_54_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_24_1[SafeUniquePositionProperty( deduped_23_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    deduped_10_1 := Concatenation( List( deduped_41_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_8_1[1 + j_2] - 1 ] ), deduped_37_1 );
-          end ) );
-    hoisted_32_1 := List( deduped_39_1, function ( i_2 )
+    hoisted_29_1 := List( deduped_45_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_30_1[deduped_3_2];
-            hoisted_1_2 := hoisted_31_1[deduped_3_2];
-            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_25_1[deduped_3_2];
+            hoisted_1_2 := hoisted_28_1[deduped_3_2];
+            return List( [ 0 .. deduped_13_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_14_1 := Concatenation( List( deduped_40_1, function ( i_2 )
-              local deduped_1_2;
-              deduped_1_2 := 1 + i_2;
-              return ListWithIdenticalEntries( deduped_4_1[deduped_1_2], deduped_5_1[deduped_1_2] );
-          end ) );
-    deduped_11_1 := List( deduped_49_1, AsList );
-    hoisted_20_1 := Concatenation( List( deduped_41_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_8_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_14_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return deduped_7_1[SafeUniquePositionProperty( deduped_48_1, function ( obj_4 )
-                               return UnderlyingVertex( obj_4 ) = hoisted_1_3;
-                           end )];
-                  end );
-          end ) );
-    deduped_21_1 := List( deduped_39_1, function ( j_2 )
-            return Product( hoisted_20_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_18_1 := Concatenation( List( deduped_41_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_8_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_38_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_38_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_36_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_15_1 := Concatenation( List( deduped_41_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_13_1[1 + deduped_12_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_11_1[deduped_3_2];
-              return List( [ 0 .. deduped_8_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_14_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return [ 0 .. deduped_7_1[SafeUniquePositionProperty( deduped_48_1, function ( obj_4 )
-                                     return (UnderlyingVertex( obj_4 ) = hoisted_1_3);
-                                 end )] - 1 ];
-                  end );
-          end ) );
-    hoisted_19_1 := List( deduped_39_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_15_1[deduped_3_2];
-            hoisted_1_2 := hoisted_18_1[deduped_3_2];
-            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    hoisted_34_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_36_1, function ( x_2 )
+    hoisted_39_1 := CAP_JIT_INCOMPLETE_LOGIC( Filtered( deduped_41_1, function ( x_2 )
                 local deduped_1_2;
                 deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+                return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_43_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_19_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
-                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_39_1, function ( j_3 )
+                            return hoisted_29_1[deduped_1_3][deduped_1_2] * deduped_31_1[deduped_1_3];
+                        end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_43_1, function ( j_3 )
                             local deduped_1_3;
                             deduped_1_3 := 1 + j_3;
-                            return hoisted_32_1[deduped_1_3][deduped_1_2] * deduped_21_1[deduped_1_3];
+                            return hoisted_37_1[deduped_1_3][deduped_1_2] * deduped_31_1[deduped_1_3];
                         end ) );
             end )[1 + AsList( alpha_1 )[(1 + CAP_JIT_INCOMPLETE_LOGIC( [ 0 .. (Length( Source( alpha_1 ) ) - 1) ][1] ))]] );
-    deduped_3_1 := List( deduped_44_1, Length );
-    deduped_33_1 := List( deduped_42_1, function ( i_2 )
-            return Product( deduped_38_1{[ 1 + Sum( deduped_3_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_3_1{[ 1 .. i_2 ]} ) ]} );
+    deduped_3_1 := List( deduped_50_1, Length );
+    deduped_38_1 := List( deduped_48_1, function ( i_2 )
+            return Product( deduped_44_1{[ 1 + Sum( deduped_3_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_3_1{[ 1 .. i_2 ]} ) ]} );
         end );
-    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, List( deduped_42_1, function ( i_2 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, source_1, range_1, ValuesOnAllObjects, List( deduped_48_1, function ( i_2 )
               local deduped_1_2, hoisted_2_2, deduped_3_2;
               deduped_3_2 := CAP_JIT_INCOMPLETE_LOGIC( i_2 );
-              hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( hoisted_34_1, Product( deduped_33_1{[ 1 .. deduped_3_2 - 1 ]} ) ), deduped_33_1[deduped_3_2] ) );
+              hoisted_2_2 := CAP_JIT_INCOMPLETE_LOGIC( REM_INT( QUO_INT( hoisted_39_1, Product( deduped_38_1{[ 1 .. deduped_3_2 - 1 ]} ) ), deduped_38_1[deduped_3_2] ) );
               deduped_1_2 := deduped_7_1[i_2];
-              return CreateCapCategoryMorphismWithAttributes( hoisted_35_1, deduped_44_1[i_2], deduped_47_1[i_2], AsList, List( [ 0 .. deduped_3_1[i_2] - 1 ], function ( i_3 )
+              return CreateCapCategoryMorphismWithAttributes( hoisted_40_1, deduped_50_1[i_2], deduped_53_1[i_2], AsList, List( [ 0 .. deduped_3_1[i_2] - 1 ], function ( i_3 )
                         return REM_INT( QUO_INT( hoisted_2_2, deduped_1_2 ^ i_3 ), deduped_1_2 );
                     end ) );
           end ) );
@@ -949,208 +1349,297 @@ end
         
 ########
 function ( cat_1, arg2_1, arg3_1 )
-    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_7_1, deduped_8_1, deduped_9_1, deduped_10_1, deduped_11_1, hoisted_12_1, hoisted_15_1, hoisted_16_1, hoisted_17_1, deduped_18_1, hoisted_20_1, hoisted_21_1, hoisted_22_1, hoisted_23_1, hoisted_24_1, hoisted_26_1, hoisted_27_1, hoisted_28_1, hoisted_29_1, deduped_32_1, deduped_33_1, hoisted_34_1, hoisted_37_1, deduped_39_1, deduped_40_1, deduped_41_1, deduped_42_1, deduped_43_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1;
-    deduped_58_1 := ValuesOfPreSheaf( arg3_1 );
-    deduped_57_1 := ValuesOfPreSheaf( arg2_1 );
-    deduped_56_1 := Source( cat_1 );
-    deduped_55_1 := SetOfGeneratingMorphisms( deduped_56_1 );
-    deduped_54_1 := deduped_57_1[2];
-    deduped_53_1 := deduped_58_1[1];
-    deduped_52_1 := SetOfObjects( deduped_56_1 );
-    deduped_51_1 := deduped_57_1[1];
-    deduped_50_1 := DefiningTripleOfUnderlyingQuiver( deduped_56_1 );
-    deduped_49_1 := ListOfValues( deduped_51_1 );
-    deduped_48_1 := deduped_50_1[1];
-    deduped_47_1 := [ 1 .. deduped_48_1 ];
-    deduped_46_1 := [ 0 .. deduped_50_1[2] - 1 ];
-    deduped_45_1 := [ 0 .. deduped_48_1 - 1 ];
-    deduped_5_1 := List( deduped_54_1, function ( logic_new_func_x_2 )
-            return Length( Source( logic_new_func_x_2 ) );
+    local deduped_1_1, deduped_2_1, deduped_4_1, deduped_5_1, deduped_6_1, deduped_7_1, deduped_8_1, deduped_10_1, deduped_11_1, deduped_12_1, deduped_13_1, deduped_15_1, hoisted_16_1, hoisted_17_1, hoisted_18_1, deduped_19_1, deduped_20_1, deduped_21_1, hoisted_22_1, hoisted_25_1, hoisted_26_1, hoisted_27_1, deduped_28_1, deduped_30_1, deduped_31_1, hoisted_32_1, hoisted_33_1, hoisted_34_1, deduped_37_1, deduped_38_1, hoisted_39_1, hoisted_42_1, deduped_44_1, deduped_45_1, deduped_46_1, deduped_47_1, deduped_48_1, deduped_49_1, deduped_50_1, deduped_51_1, deduped_52_1, deduped_53_1, deduped_54_1, deduped_55_1, deduped_56_1, deduped_57_1, deduped_58_1, deduped_59_1, deduped_60_1, deduped_61_1, deduped_62_1, deduped_63_1;
+    deduped_63_1 := ValuesOfPreSheaf( arg3_1 );
+    deduped_62_1 := ValuesOfPreSheaf( arg2_1 );
+    deduped_61_1 := Source( cat_1 );
+    deduped_60_1 := deduped_62_1[2];
+    deduped_59_1 := deduped_63_1[1];
+    deduped_58_1 := SetOfObjects( deduped_61_1 );
+    deduped_57_1 := deduped_62_1[1];
+    deduped_56_1 := DefiningTripleOfUnderlyingQuiver( deduped_61_1 );
+    deduped_55_1 := ListOfValues( deduped_57_1 );
+    deduped_54_1 := deduped_56_1[1];
+    deduped_53_1 := [ 1 .. deduped_54_1 ];
+    deduped_52_1 := [ 0 .. deduped_56_1[2] - 1 ];
+    deduped_51_1 := [ 0 .. deduped_54_1 - 1 ];
+    deduped_5_1 := deduped_56_1[3];
+    deduped_7_1 := List( deduped_52_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][1];
         end );
-    deduped_44_1 := [ 0 .. Sum( List( deduped_46_1, function ( j_2 )
-                    return deduped_5_1[1 + j_2];
+    deduped_6_1 := List( deduped_52_1, function ( m_2 )
+            return deduped_5_1[1 + m_2][2];
+        end );
+    deduped_1_1 := List( deduped_57_1, Length );
+    deduped_8_1 := List( deduped_52_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_58_1[1 + deduped_7_1[deduped_2_2]] ) );
+        end );
+    deduped_50_1 := [ 0 .. Sum( List( deduped_52_1, function ( i_2 )
+                    return deduped_8_1[1 + i_2][1];
                 end ) ) - 1 ];
-    deduped_4_1 := List( deduped_53_1, Length );
-    deduped_2_1 := List( deduped_52_1, UnderlyingVertex );
-    deduped_1_1 := List( deduped_51_1, Length );
-    deduped_43_1 := Concatenation( List( deduped_45_1, function ( i_2 )
+    deduped_4_1 := List( deduped_59_1, Length );
+    deduped_2_1 := List( deduped_58_1, UnderlyingVertex );
+    deduped_49_1 := Concatenation( List( deduped_51_1, function ( o_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + i_2;
+              deduped_2_2 := 1 + o_2;
               hoisted_1_2 := deduped_2_1[deduped_2_2];
-              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_52_1, function ( obj_3 )
+              return ListWithIdenticalEntries( deduped_1_1[deduped_2_2], deduped_4_1[SafeUniquePositionProperty( deduped_58_1, function ( obj_3 )
                          return UnderlyingVertex( obj_3 ) = hoisted_1_2;
                      end )] );
           end ) );
-    deduped_42_1 := Product( deduped_43_1 );
-    deduped_41_1 := [ 0 .. deduped_42_1 - 1 ];
-    deduped_10_1 := List( deduped_45_1, function ( i_2 )
-            return Sum( List( [ 1 .. i_2 ], function ( j_3 )
-                      return deduped_1_1[j_3];
+    deduped_48_1 := [ 0 .. Sum( List( deduped_52_1, function ( m_2 )
+                    return deduped_1_1[1 + deduped_5_1[(1 + m_2)][2]];
+                end ) ) - 1 ];
+    deduped_47_1 := Product( deduped_49_1 );
+    deduped_46_1 := [ 0 .. deduped_47_1 - 1 ];
+    deduped_20_1 := SetOfGeneratingMorphisms( deduped_61_1 );
+    deduped_31_1 := List( deduped_52_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + m_2;
+            deduped_1_2 := deduped_1_1[1 + deduped_6_1[deduped_2_2]];
+            return NTuple( 2, [ 0 .. deduped_1_2 - 1 ], ListWithIdenticalEntries( deduped_1_2, deduped_20_1[deduped_2_2] ) );
+        end );
+    deduped_13_1 := UnderlyingQuiverAlgebra( deduped_61_1 );
+    deduped_12_1 := List( deduped_51_1, function ( o_2 )
+            local deduped_1_2, deduped_2_2;
+            deduped_2_2 := 1 + o_2;
+            deduped_1_2 := deduped_1_1[deduped_2_2];
+            return NTuple( 2, deduped_1_2, ListWithIdenticalEntries( deduped_1_2, deduped_58_1[deduped_2_2] ) );
+        end );
+    deduped_11_1 := List( deduped_51_1, function ( o_2 )
+            return deduped_1_1[1 + o_2];
+        end );
+    deduped_30_1 := List( deduped_52_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_6_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_11_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_11_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_61_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
                   end ) );
         end );
-    deduped_9_1 := deduped_50_1[3];
-    hoisted_28_1 := Concatenation( List( deduped_46_1, function ( j_2 )
+    hoisted_33_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_30_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_31_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
+                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_49_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_49_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_46_1, function ( i_4 )
+                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
+                          end );
+                  end );
+          end ) );
+    deduped_21_1 := List( deduped_63_1[2], AsList );
+    hoisted_32_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_31_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_30_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_58_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
+          end ) );
+    deduped_10_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+              return ListWithIdenticalEntries( deduped_8_1[1 + i_2][1], deduped_47_1 );
+          end ) );
+    hoisted_34_1 := List( deduped_50_1, function ( i_2 )
+            local hoisted_1_2, hoisted_2_2, deduped_3_2;
+            deduped_3_2 := 1 + i_2;
+            hoisted_2_2 := hoisted_32_1[deduped_3_2];
+            hoisted_1_2 := hoisted_33_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
+                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                end );
+        end );
+    hoisted_27_1 := Concatenation( List( deduped_52_1, function ( m_2 )
               local hoisted_1_2, deduped_2_2;
-              deduped_2_2 := 1 + j_2;
-              hoisted_1_2 := deduped_10_1[1 + deduped_9_1[deduped_2_2][2]];
-              return List( [ 0 .. deduped_5_1[deduped_2_2] - 1 ], function ( i_3 )
+              deduped_2_2 := 1 + m_2;
+              hoisted_1_2 := deduped_2_1[1 + deduped_7_1[deduped_2_2]];
+              return ListWithIdenticalEntries( deduped_1_1[1 + deduped_6_1[deduped_2_2]], deduped_4_1[SafeUniquePositionProperty( deduped_58_1, function ( obj_3 )
+                         return UnderlyingVertex( obj_3 ) = hoisted_1_2;
+                     end )] );
+          end ) );
+    deduped_28_1 := List( deduped_48_1, function ( j_2 )
+            return Product( hoisted_27_1{[ 1 .. j_2 ]} );
+        end );
+    hoisted_18_1 := List( deduped_58_1, function ( logic_new_func_x_2 )
+            return QuiverVertexAsIdentityPath( UnderlyingVertex( logic_new_func_x_2 ) );
+        end );
+    hoisted_17_1 := List( deduped_60_1, function ( logic_new_func_x_2 )
+            return Length( Source( logic_new_func_x_2 ) );
+        end );
+    hoisted_16_1 := List( deduped_60_1, AsList );
+    deduped_19_1 := List( deduped_52_1, function ( m_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := 1 + m_2;
+            deduped_2_2 := 1 + deduped_7_1[deduped_3_2];
+            deduped_1_2 := deduped_58_1[deduped_2_2];
+            return NTuple( 2, hoisted_16_1[deduped_3_2], ListWithIdenticalEntries( hoisted_17_1[deduped_3_2], CreateCapCategoryMorphismWithAttributes( deduped_61_1, deduped_1_2, deduped_1_2, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, hoisted_18_1[deduped_2_2] ) ) ) );
+        end );
+    deduped_15_1 := List( deduped_52_1, function ( i_2 )
+            local deduped_1_2, deduped_2_2, deduped_3_2;
+            deduped_3_2 := deduped_7_1[1 + i_2];
+            deduped_2_2 := 1 + deduped_3_2;
+            deduped_1_2 := Sum( deduped_11_1{[ 1 .. deduped_3_2 ]} );
+            return NTuple( 2, [ deduped_1_2 .. deduped_1_2 + deduped_11_1[deduped_2_2] - 1 ], List( deduped_12_1[deduped_2_2][2], function ( objC_3 )
+                      return CreateCapCategoryMorphismWithAttributes( deduped_61_1, objC_3, objC_3, UnderlyingQuiverAlgebraElement, PathAsAlgebraElement( deduped_13_1, QuiverVertexAsIdentityPath( UnderlyingVertex( objC_3 ) ) ) );
+                  end ) );
+        end );
+    hoisted_25_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, deduped_3_2;
+              deduped_3_2 := 1 + i_2;
+              hoisted_2_2 := deduped_15_1[deduped_3_2][1];
+              hoisted_1_2 := deduped_19_1[deduped_3_2][1];
+              return List( [ 0 .. deduped_8_1[deduped_3_2][1] - 1 ], function ( i_3 )
                       local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (i_3 + hoisted_1_2);
-                      hoisted_2_3 := deduped_43_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_41_1, function ( i_4 )
+                      deduped_3_3 := hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
+                      hoisted_2_3 := deduped_49_1[1 + deduped_3_3];
+                      hoisted_1_3 := Product( deduped_49_1{[ 1 .. deduped_3_3 ]} );
+                      return List( deduped_46_1, function ( i_4 )
                               return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
                           end );
                   end );
           end ) );
-    hoisted_26_1 := List( deduped_58_1[2], AsList );
-    hoisted_24_1 := UnderlyingQuiverAlgebra( deduped_56_1 );
-    hoisted_23_1 := List( deduped_55_1, function ( logic_new_func_x_2 )
-            return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_2 ) ) );
-        end );
-    hoisted_22_1 := List( deduped_55_1, UnderlyingQuiverAlgebraElement );
-    hoisted_21_1 := List( deduped_55_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Source( logic_new_func_x_2 ) );
-        end );
-    hoisted_20_1 := List( deduped_55_1, function ( logic_new_func_x_2 )
-            return UnderlyingVertex( Range( logic_new_func_x_2 ) );
-        end );
-    hoisted_27_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local deduped_4_2, deduped_5_2, deduped_6_2, deduped_7_2, deduped_8_2;
-              deduped_8_2 := 1 + j_2;
-              deduped_7_2 := deduped_5_1[deduped_8_2];
-              deduped_6_2 := hoisted_22_1[deduped_8_2];
-              deduped_5_2 := hoisted_21_1[deduped_8_2];
-              deduped_4_2 := hoisted_20_1[deduped_8_2];
-              if IdFunc( function (  )
-                          if deduped_4_2 = deduped_5_2 then
-                              return deduped_6_2 = PathAsAlgebraElement( hoisted_24_1, hoisted_23_1[deduped_8_2] );
-                          else
-                              return false;
-                          fi;
-                          return;
-                      end )(  ) then
-                  return ListWithIdenticalEntries( deduped_7_2, [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_52_1, function ( obj_3 )
-                                   return (UnderlyingVertex( obj_3 ) = deduped_5_2);
-                               end )] - 1 ] );
-              else
-                  return ListWithIdenticalEntries( deduped_7_2, hoisted_26_1[SafeUniquePositionProperty( deduped_55_1, function ( mor_3 )
-                             if UnderlyingVertex( Source( mor_3 ) ) = deduped_5_2 and UnderlyingVertex( Range( mor_3 ) ) = deduped_4_2 then
-                                 return UnderlyingQuiverAlgebraElement( mor_3 ) = deduped_6_2;
-                             else
-                                 return false;
-                             fi;
-                             return;
-                         end )] );
-              fi;
-              return;
+    hoisted_22_1 := Concatenation( List( deduped_52_1, function ( i_2 )
+              local hoisted_1_2, hoisted_2_2, hoisted_3_2, hoisted_4_2, hoisted_5_2, hoisted_6_2, deduped_7_2, deduped_8_2, deduped_9_2, deduped_10_2;
+              deduped_10_2 := 1 + i_2;
+              deduped_9_2 := deduped_19_1[deduped_10_2];
+              deduped_8_2 := deduped_9_2[2];
+              deduped_7_2 := deduped_15_1[deduped_10_2][2];
+              hoisted_6_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return QuiverVertexAsIdentityPath( UnderlyingVertex( Source( logic_new_func_x_3 ) ) );
+                  end );
+              hoisted_5_2 := List( deduped_7_2, UnderlyingQuiverAlgebraElement );
+              hoisted_4_2 := List( deduped_8_2, UnderlyingQuiverAlgebraElement );
+              hoisted_3_2 := List( deduped_8_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Source( logic_new_func_x_3 ) );
+                  end );
+              hoisted_2_2 := List( deduped_7_2, function ( logic_new_func_x_3 )
+                      return UnderlyingVertex( Range( logic_new_func_x_3 ) );
+                  end );
+              hoisted_1_2 := deduped_9_2[1];
+              return List( [ 0 .. deduped_8_1[deduped_10_2][1] - 1 ], function ( i_3 )
+                      local deduped_4_3, deduped_5_3, deduped_6_3, deduped_7_3, deduped_8_3;
+                      deduped_8_3 := 1 + i_3;
+                      deduped_7_3 := hoisted_3_2[deduped_8_3];
+                      deduped_6_3 := 1 + hoisted_1_2[deduped_8_3];
+                      deduped_5_3 := hoisted_2_2[deduped_6_3];
+                      deduped_4_3 := hoisted_4_2[deduped_8_3] * hoisted_5_2[deduped_6_3];
+                      if IdFunc( function (  )
+                                  if deduped_5_3 = deduped_7_3 then
+                                      return deduped_4_3 = PathAsAlgebraElement( deduped_13_1, hoisted_6_2[deduped_8_3] );
+                                  else
+                                      return false;
+                                  fi;
+                                  return;
+                              end )(  ) then
+                          return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_58_1, function ( obj_4 )
+                                         return (UnderlyingVertex( obj_4 ) = deduped_7_3);
+                                     end )] - 1 ];
+                      else
+                          return deduped_21_1[SafeUniquePositionProperty( deduped_20_1, function ( mor_4 )
+                                   if UnderlyingVertex( Source( mor_4 ) ) = deduped_7_3 and UnderlyingVertex( Range( mor_4 ) ) = deduped_5_3 then
+                                       return UnderlyingQuiverAlgebraElement( mor_4 ) = deduped_4_3;
+                                   else
+                                       return false;
+                                   fi;
+                                   return;
+                               end )];
+                      fi;
+                      return;
+                  end );
           end ) );
-    deduped_7_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              return ListWithIdenticalEntries( Length( [ 0 .. deduped_5_1[1 + j_2] - 1 ] ), deduped_42_1 );
-          end ) );
-    hoisted_29_1 := List( deduped_44_1, function ( i_2 )
+    hoisted_26_1 := List( deduped_50_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2, deduped_3_2;
             deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_27_1[deduped_3_2];
-            hoisted_1_2 := hoisted_28_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
+            hoisted_2_2 := hoisted_22_1[deduped_3_2];
+            hoisted_1_2 := hoisted_25_1[deduped_3_2];
+            return List( [ 0 .. deduped_10_1[deduped_3_2] - 1 ], function ( i_3 )
                     return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
                 end );
         end );
-    deduped_11_1 := Concatenation( List( deduped_45_1, function ( i_2 )
-              local deduped_1_2;
-              deduped_1_2 := 1 + i_2;
-              return ListWithIdenticalEntries( deduped_1_1[deduped_1_2], deduped_2_1[deduped_1_2] );
-          end ) );
-    deduped_8_1 := List( deduped_54_1, AsList );
-    hoisted_17_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return deduped_4_1[SafeUniquePositionProperty( deduped_52_1, function ( obj_4 )
-                               return UnderlyingVertex( obj_4 ) = hoisted_1_3;
-                           end )];
-                  end );
-          end ) );
-    deduped_18_1 := List( deduped_44_1, function ( j_2 )
-            return Product( hoisted_17_1{[ 1 .. j_2 ]} );
-        end );
-    hoisted_15_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3, hoisted_2_3, deduped_3_3;
-                      deduped_3_3 := 1 + (hoisted_1_2[1 + i_3] + hoisted_2_2);
-                      hoisted_2_3 := deduped_43_1[deduped_3_3];
-                      hoisted_1_3 := Product( deduped_43_1{[ 1 .. deduped_3_3 - 1 ]} );
-                      return List( deduped_41_1, function ( i_4 )
-                              return REM_INT( QUO_INT( i_4, hoisted_1_3 ), hoisted_2_3 );
-                          end );
-                  end );
-          end ) );
-    hoisted_12_1 := Concatenation( List( deduped_46_1, function ( j_2 )
-              local hoisted_1_2, hoisted_2_2, deduped_3_2;
-              deduped_3_2 := 1 + j_2;
-              hoisted_2_2 := deduped_10_1[1 + deduped_9_1[deduped_3_2][1]];
-              hoisted_1_2 := deduped_8_1[deduped_3_2];
-              return List( [ 0 .. deduped_5_1[deduped_3_2] - 1 ], function ( i_3 )
-                      local hoisted_1_3;
-                      hoisted_1_3 := deduped_11_1[1 + (hoisted_1_2[1 + i_3] + hoisted_2_2)];
-                      return [ 0 .. deduped_4_1[SafeUniquePositionProperty( deduped_52_1, function ( obj_4 )
-                                     return (UnderlyingVertex( obj_4 ) = hoisted_1_3);
-                                 end )] - 1 ];
-                  end );
-          end ) );
-    hoisted_16_1 := List( deduped_44_1, function ( i_2 )
-            local hoisted_1_2, hoisted_2_2, deduped_3_2;
-            deduped_3_2 := 1 + i_2;
-            hoisted_2_2 := hoisted_12_1[deduped_3_2];
-            hoisted_1_2 := hoisted_15_1[deduped_3_2];
-            return List( [ 0 .. deduped_7_1[deduped_3_2] - 1 ], function ( i_3 )
-                    return hoisted_2_2[1 + hoisted_1_2[(1 + i_3)]];
-                end );
-        end );
-    deduped_40_1 := Filtered( deduped_41_1, function ( x_2 )
+    deduped_45_1 := Filtered( deduped_46_1, function ( x_2 )
             local deduped_1_2;
             deduped_1_2 := 1 + CAP_JIT_INCOMPLETE_LOGIC( x_2 );
-            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_44_1, function ( j_3 )
+            return CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_48_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_16_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
-                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_44_1, function ( j_3 )
+                        return hoisted_26_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
+                    end ) ) = CAP_JIT_INCOMPLETE_LOGIC( Sum( deduped_48_1, function ( j_3 )
                         local deduped_1_3;
                         deduped_1_3 := 1 + j_3;
-                        return hoisted_29_1[deduped_1_3][deduped_1_2] * deduped_18_1[deduped_1_3];
+                        return hoisted_34_1[deduped_1_3][deduped_1_2] * deduped_28_1[deduped_1_3];
                     end ) );
         end );
-    deduped_39_1 := Length( deduped_40_1 );
-    hoisted_37_1 := Range( cat_1 );
-    deduped_32_1 := List( deduped_49_1, Length );
-    deduped_33_1 := List( deduped_47_1, function ( i_2 )
-            return Product( deduped_43_1{[ 1 + Sum( deduped_32_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_32_1{[ 1 .. i_2 ]} ) ]} );
+    deduped_44_1 := Length( deduped_45_1 );
+    hoisted_42_1 := Range( cat_1 );
+    deduped_37_1 := List( deduped_55_1, Length );
+    deduped_38_1 := List( deduped_53_1, function ( i_2 )
+            return Product( deduped_49_1{[ 1 + Sum( deduped_37_1{[ 1 .. (i_2 - 1) ]} ) .. Sum( deduped_37_1{[ 1 .. i_2 ]} ) ]} );
         end );
-    hoisted_34_1 := List( deduped_47_1, function ( i_2 )
+    hoisted_39_1 := List( deduped_53_1, function ( i_2 )
             local hoisted_1_2, hoisted_2_2;
-            hoisted_2_2 := deduped_33_1[i_2];
-            hoisted_1_2 := Product( deduped_33_1{[ 1 .. i_2 - 1 ]} );
-            return List( deduped_41_1, function ( i_3 )
+            hoisted_2_2 := deduped_38_1[i_2];
+            hoisted_1_2 := Product( deduped_38_1{[ 1 .. i_2 - 1 ]} );
+            return List( deduped_46_1, function ( i_3 )
                     return REM_INT( QUO_INT( i_3, hoisted_1_2 ), hoisted_2_2 );
                 end );
         end );
-    return List( [ 0 .. deduped_39_1 - 1 ], function ( i_2 )
+    return List( [ 0 .. deduped_44_1 - 1 ], function ( i_2 )
             local hoisted_1_2;
-            hoisted_1_2 := 1 + deduped_40_1[(1 + REM_INT( i_2, deduped_39_1 ))];
-            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, List( deduped_47_1, function ( i_3 )
+            hoisted_1_2 := 1 + deduped_45_1[(1 + REM_INT( i_2, deduped_44_1 ))];
+            return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg3_1, ValuesOnAllObjects, List( deduped_53_1, function ( i_3 )
                       local deduped_1_3, hoisted_2_3;
-                      hoisted_2_3 := hoisted_34_1[i_3][hoisted_1_2];
+                      hoisted_2_3 := hoisted_39_1[i_3][hoisted_1_2];
                       deduped_1_3 := deduped_4_1[i_3];
-                      return CreateCapCategoryMorphismWithAttributes( hoisted_37_1, deduped_49_1[i_3], deduped_53_1[i_3], AsList, List( [ 0 .. deduped_32_1[i_3] - 1 ], function ( i_4 )
+                      return CreateCapCategoryMorphismWithAttributes( hoisted_42_1, deduped_55_1[i_3], deduped_59_1[i_3], AsList, List( [ 0 .. deduped_37_1[i_3] - 1 ], function ( i_4 )
                                 return REM_INT( QUO_INT( hoisted_2_3, deduped_1_3 ^ i_4 ), deduped_1_3 );
                             end ) );
                   end ) );

--- a/FunctorCategories/gap/precompiled_categories/PreSheavesOfFreeAlgebroidInCategoryOfRowsPrecompiled.gi
+++ b/FunctorCategories/gap/precompiled_categories/PreSheavesOfFreeAlgebroidInCategoryOfRowsPrecompiled.gi
@@ -546,8 +546,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ), hoisted_2_1[o_2], UnderlyingMatrix, CertainRows( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -572,8 +572,8 @@ function ( cat_1, alpha_1, S_1, i_1 )
               deduped_2_2 := List( S_1, function ( F_3 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( F_3 )[1][o_2] ) ) );
                   end );
-              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} ) + 1;
-              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 .. deduped_1_2 - 1 + deduped_2_2[i_1] ] ) );
+              deduped_1_2 := Sum( deduped_2_2{hoisted_4_1} );
+              return CreateCapCategoryMorphismWithAttributes( hoisted_5_1, hoisted_1_1[o_2], CAP_JIT_INCOMPLETE_LOGIC( hoisted_2_1[o_2] ), UnderlyingMatrix, CertainColumns( hoisted_3_1[o_2], [ deduped_1_2 + 1 .. deduped_1_2 + deduped_2_2[i_1] ] ) );
           end ) );
 end
 ########
@@ -935,8 +935,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_3_2 := SyzygiesOfRows( deduped_7_2 );
                 deduped_6_2 := UniqueRightDivide( UnionOfColumns( deduped_1_1, deduped_10_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CertainColumns( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
+                            deduped_1_3 := Sum( deduped_12_2{[ 1 .. i_3 - 1 ]} );
+                            return CertainColumns( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_12_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Source( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) );
                         end ) ), SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_11_2, deduped_9_2{deduped_5_1} )) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -987,8 +987,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_2_2 := SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_6_1} ) + (- UnionOfColumns( deduped_3_1, deduped_8_2, deduped_6_2{hoisted_7_1} )) );
               deduped_4_2 := UniqueRightDivide( UnionOfColumns( deduped_3_1, hoisted_2_1[o_2], List( hoisted_8_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CertainColumns( hoisted_2_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CertainColumns( hoisted_2_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) );
                       end ) ), SyzygiesOfRows( UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_11_1} ) + (- UnionOfColumns( deduped_3_1, deduped_7_2, deduped_5_2{hoisted_12_1} )) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_15_1, deduped_14_1[o_2], CreateCapCategoryObjectWithAttributes( deduped_15_1, RankOfObject, NumberColumns( deduped_4_2 ) ), UnderlyingMatrix, deduped_4_2 );
           end ) );
@@ -1351,13 +1351,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Range( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_7_1} );
               deduped_3_2 := List( hoisted_4_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) ) * UnionOfColumns( HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_2_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_2_1 ), HomalgZeroMatrix( deduped_1_3, Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_2_1 ) );
                   end );
-              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainRows( SyzygiesOfColumns( UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_5_1} ) + (- UnionOfRows( deduped_2_1, deduped_5_2, deduped_3_2{hoisted_6_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CAP_JIT_INCOMPLETE_LOGIC( Range( CAP_JIT_INCOMPLETE_LOGIC( hoisted_1_1[o_2] ) ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_2_2 ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -2089,13 +2089,13 @@ function ( cat_1, morphisms_1, k_1, P_1 )
                       return CAP_JIT_INCOMPLETE_LOGIC( RankOfObject( Source( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( eta_3 )[o_2] ) ) ) );
                   end );
               deduped_5_2 := Sum( deduped_6_2 );
-              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} ) + 1;
+              deduped_4_2 := Sum( deduped_6_2{hoisted_6_1} );
               deduped_3_2 := List( hoisted_3_1, function ( i_3 )
                       local deduped_1_3;
                       deduped_1_3 := deduped_6_2[i_3];
                       return UnionOfRows( HomalgZeroMatrix( Sum( deduped_6_2{[ 1 .. (i_3 - 1) ]} ), deduped_1_3, deduped_1_1 ), HomalgIdentityMatrix( deduped_1_3, deduped_1_1 ), HomalgZeroMatrix( Sum( deduped_6_2{[ (i_3 + 1) .. deduped_11_1 ]} ), deduped_1_3, deduped_1_1 ) ) * CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) )[o_2] ) ) );
                   end );
-              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 .. deduped_4_2 - 1 + deduped_6_2[k_1] ] );
+              deduped_2_2 := CertainColumns( SyzygiesOfRows( UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_4_1} ) + (- UnionOfColumns( deduped_1_1, deduped_5_2, deduped_3_2{hoisted_5_1} )) ), [ deduped_4_2 + 1 .. deduped_4_2 + deduped_6_2[k_1] ] );
               return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_2_2 ) ), CAP_JIT_INCOMPLETE_LOGIC( Source( CAP_JIT_INCOMPLETE_LOGIC( hoisted_8_1[o_2] ) ) ), UnderlyingMatrix, deduped_2_2 );
           end ) );
 end
@@ -2184,8 +2184,8 @@ function ( cat_1, morphisms_1 )
                 hoisted_5_2 := SyzygiesOfColumns( deduped_7_2 );
                 deduped_6_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_10_2, deduped_8_2{deduped_5_1} )) ), UnionOfRows( deduped_1_1, deduped_11_2 - RowRankOfMatrix( deduped_7_2 ), List( deduped_3_1, function ( i_3 )
                             local deduped_1_3;
-                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_13_2[i_3]) ] );
+                            deduped_1_3 := Sum( deduped_13_2{[ 1 .. i_3 - 1 ]} );
+                            return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOfPreSheaf( Range( CAP_JIT_INCOMPLETE_LOGIC( morphisms_1[i_3] ) ) )[2][m_2] ) ) ) * CertainRows( hoisted_5_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_13_2[i_3]) ] );
                         end ) ) );
                 return CreateCapCategoryMorphismWithAttributes( deduped_10_1, CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberRows( deduped_6_2 ) ), CreateCapCategoryObjectWithAttributes( deduped_10_1, RankOfObject, NumberColumns( deduped_6_2 ) ), UnderlyingMatrix, deduped_6_2 );
             end ) ) );
@@ -2236,8 +2236,8 @@ function ( cat_1, P_1, morphisms_1, L_1, morphismsp_1, Pp_1 )
               hoisted_3_2 := SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_9_1} ) + (- UnionOfRows( deduped_1_1, deduped_8_2, deduped_6_2{hoisted_10_1} )) );
               deduped_4_2 := UniqueLeftDivide( SyzygiesOfColumns( UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_4_1} ) + (- UnionOfRows( deduped_1_1, deduped_7_2, deduped_5_2{hoisted_5_1} )) ), UnionOfRows( deduped_1_1, hoisted_6_1[o_2], List( hoisted_11_1, function ( i_3 )
                           local deduped_1_3;
-                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} ) + 1;
-                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ deduped_1_3 .. (deduped_1_3 - 1 + deduped_10_2[i_3]) ] );
+                          deduped_1_3 := Sum( deduped_10_2{[ 1 .. i_3 - 1 ]} );
+                          return CAP_JIT_INCOMPLETE_LOGIC( UnderlyingMatrix( CAP_JIT_INCOMPLETE_LOGIC( ValuesOnAllObjects( CAP_JIT_INCOMPLETE_LOGIC( L_1[i_3] ) )[o_2] ) ) ) * CertainRows( hoisted_3_2, [ (deduped_1_3 + 1) .. (deduped_1_3 + deduped_10_2[i_3]) ] );
                       end ) ) );
               return CreateCapCategoryMorphismWithAttributes( deduped_15_1, CreateCapCategoryObjectWithAttributes( deduped_15_1, RankOfObject, NumberRows( deduped_4_2 ) ), deduped_14_1[o_2], UnderlyingMatrix, deduped_4_2 );
           end ) );


### PR DESCRIPTION
using TensorizeObject/MorphismWithObject/MorphismInRangeCategoryOfHomomorphismStructure
from FiniteCocompletions v2023.08-09

CoYonedaLemmaOnObjects/Morphisms now returns

cells in AssociatedCategoryOfCoequalizerPairsOfSourceCategory( PSh )

instead of

cells in AssociatedCategoryOfColimitQuiversOfSourceCategory( PSh )