### PR TITLE
Reduce the dependency of tests on HigherHomologicalAlgebra

### DIFF
--- a/CatReps/PackageInfo.g
+++ b/CatReps/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CatReps",
 Subtitle := "Representations and cohomology of finite categories",
-Version := "2023.08-02",
+Version := "2023.08-03",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
@@ -100,7 +100,7 @@ Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
-                   [ "CAP", ">= 2023.08-07" ],
+                   [ "CAP", ">= 2023.08-09" ],
                    [ "MonoidalCategories", ">= 2021.08-01" ],
                    [ "LinearAlgebraForCAP", ">= 2021.07-01" ],
                    [ "FinSetsForCAP", ">= 2022.05-07" ],

--- a/CatReps/README.md
+++ b/CatReps/README.md
@@ -58,7 +58,7 @@ The supported categorical doctrine of the category of representations is
 
 ```gap
 gap> Display( CatReps );
-102 primitive operations were used to derive 356 operations for this category
+103 primitive operations were used to derive 356 operations for this category
 which constructively
 * IsEquippedWithHomomorphismStructure
 * IsLinearCategoryOverCommutativeRing

--- a/CatReps/examples/CategoryOfRepresentations.g
+++ b/CatReps/examples/CategoryOfRepresentations.g
@@ -38,7 +38,7 @@ Display( CatReps );
 #! RightQuiver( "q(2)[a:1->1,b:1->2,c:2->2]" ) ) ) / relations,
 #! Category of matrices over GF(3) ):
 #! 
-#! 102 primitive operations were used to derive 356 operations for this category
+#! 103 primitive operations were used to derive 356 operations for this category
 #! which algorithmically
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing

--- a/CatReps/examples/notebooks/CategoryOfRepresentations.ipynb
+++ b/CatReps/examples/notebooks/CategoryOfRepresentations.ipynb
@@ -517,7 +517,7 @@
      "text": [
       "A CAP category with name FunctorCategory( Algebroid( GF(3), FreeCategory( RightQuiver( \"q(2)[a:1->1,b:1->2,c:2->2]\" ) ) ) / relations, Category of matrices over GF(3) ):\n",
       "\n",
-      "102 primitive operations were used to derive 356 operations for this category which algorithmically\n",
+      "103 primitive operations were used to derive 356 operations for this category which algorithmically\n",
       "* IsEquippedWithHomomorphismStructure\n",
       "* IsLinearCategoryOverCommutativeRing\n",
       "* IsSymmetricMonoidalCategory\n",

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.08-22",
+Version := "2023.08-23",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/examples/presheaves_of_algebroid.g
+++ b/FunctorCategories/examples/presheaves_of_algebroid.g
@@ -137,18 +137,7 @@ Display( P );
 #! An object in PreSheaves( Algebroid( Q, FreeCategory( RightQuiver( "q(4)[x:1->1,
 #! a:1->2,b:2->4,c:1->3,d:3->4,y:4->4]" ) ) ) / relations, Rows( Q ) ) given by
 #! the above data
-CP := CreateComplex( ComplexesCategoryByCochains( PSh ), P, 0 );
-#! <An object in Complexes category by cochains( PreSheaves( Algebroid( Q,
-#! FreeCategory( RightQuiver( "q(4)[x:1->1,a:1->2,b:2->4,c:1->3,d:3->4,y:4->4]" ) ) )
-#! / relations, Rows( Q ) ) ) supported on the interval [ 0 ]>
-I_CP := InjectiveResolution( CP, true );
-#! <An object in Complexes category by cochains( PreSheaves( Algebroid( Q,
-#! FreeCategory( RightQuiver( "q(4)[x:1->1,a:1->2,b:2->4,c:1->3,d:3->4,y:4->4]" ) ) )
-#! / relations, Rows( Q ) ) ) supported on the interval [ 0 .. 1 ]>
-IsWellDefined( I_CP ) and CohomologySupport( I_CP ) = [ 0 ];
-#! true
-q := QuasiIsomorphismFromProjectiveResolution( CP, true );;
-IsWellDefined( q ) and IsQuasiIsomorphism( q );
+IsWellDefined( MonomorphismIntoSomeInjectiveObject( P ) );
 #! true
 #! @EndExample
 #! @EndChunk

--- a/FunctorCategories/examples/presheaves_of_algebroid_from_data_tables.g
+++ b/FunctorCategories/examples/presheaves_of_algebroid_from_data_tables.g
@@ -137,18 +137,7 @@ Display( P );
 #! An object in PreSheaves( Q-algebroid( {1,2,3,4}[x:1-≻1,a:1-≻2,b:2-≻4,c:1-≻3,d:3-≻4,
 #! y:4-≻4] ) defined by 4 objects and 6 generating morphisms, Rows( Q ) ) given by
 #! the above data
-CP := CreateComplex( ComplexesCategoryByCochains( PSh ), P, 0 );
-#! <An object in Complexes category by cochains( PreSheaves( Q-algebroid( {1,2,3,4}[
-#! x:1-≻1,a:1-≻2,b:2-≻4,c:1-≻3,d:3-≻4,y:4-≻4] ) defined by 4 objects and 6 generating
-#! morphisms, Rows( Q ) ) ) supported on the interval [ 0 ]>
-I_CP := InjectiveResolution( CP, true );
-#! <An object in Complexes category by cochains( PreSheaves( Q-algebroid( {1,2,3,4}[
-#! x:1-≻1,a:1-≻2,b:2-≻4,c:1-≻3,d:3-≻4,y:4-≻4] ) defined by 4 objects and 6 generating
-#! morphisms, Rows( Q ) ) ) supported on the interval [ 0 .. 1 ]>
-IsWellDefined( I_CP ) and CohomologySupport( I_CP ) = [ 0 ];
-#! true
-q := QuasiIsomorphismFromProjectiveResolution( CP, true );;
-IsWellDefined( q ) and IsQuasiIsomorphism( q );
+IsWellDefined( MonomorphismIntoSomeInjectiveObject( P ) );
 #! true
 #! @EndExample
 #! @EndChunk

--- a/FunctorCategories/tst/100_LoadPackage.tst
+++ b/FunctorCategories/tst/100_LoadPackage.tst
@@ -24,8 +24,6 @@ gap> LoadPackage( "Toposes" );
 true
 gap> LoadPackage( "Locales" );
 true
-gap> LoadPackage( "ComplexesCategories" );
-true
 gap> LoadPackage( "FunctorCategories" );
 true
 gap> SetInfoLevel( InfoPackageLoading, package_loading_info_level );;


### PR DESCRIPTION
Don't rely on projective and injective resolutions to test projective and injective operations in presheaves categories, hence dropping the dependency on complexes categories in the tests of functor categories.

resolves https://github.com/homalg-project/CategoricalTowers/issues/343