### PR TITLE
Adjust to changes to the compilation of `Iterated`

### DIFF
--- a/SubcategoriesForCAP/PackageInfo.g
+++ b/SubcategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "SubcategoriesForCAP",
 Subtitle := "Subcategory and other related constructors for CAP categories",
-Version := "2023.08-01",
+Version := "2023.09-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/SubcategoriesForCAP/examples/PrecompileSliceCategory.g
+++ b/SubcategoriesForCAP/examples/PrecompileSliceCategory.g
@@ -35,6 +35,15 @@ CapJitAddLogicTemplate(
     )
 );
 
+# Iterated: function always choosing first value
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "list" ],
+        src_template := "Iterated( list, { x, y } -> x )",
+        dst_template := "list[1]",
+    )
+);
+
 # Length( [ 1 .. n ] ) -> n
 CapJitAddLogicTemplate(
     rec(

--- a/SubcategoriesForCAP/gap/precompiled_categories/SliceCategoryOfCategoryOfRowsOfFieldOverTensorUnitPrecompiled.gi
+++ b/SubcategoriesForCAP/gap/precompiled_categories/SliceCategoryOfCategoryOfRowsOfFieldOverTensorUnitPrecompiled.gi
@@ -41,14 +41,14 @@ end
         
 ########
 function ( cat_1, objects_1 )
-    local morphism_attr_1_1, deduped_2_1;
+    local deduped_1_1, deduped_2_1;
     deduped_2_1 := AmbientCategory( cat_1 );
-    morphism_attr_1_1 := Iterated( List( objects_1, function ( logic_new_func_x_2 )
+    deduped_1_1 := Iterated( List( objects_1, function ( logic_new_func_x_2 )
               return UnderlyingMatrix( UnderlyingMorphism( logic_new_func_x_2 ) );
           end ), function ( I_2, J_2 )
             return ReducedSyzygiesOfRows( I_2, J_2 ) * I_2;
         end );
-    return CreateCapCategoryObjectWithAttributes( cat_1, UnderlyingMorphism, CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberRows( morphism_attr_1_1 ) ), CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberColumns( morphism_attr_1_1 ) ), UnderlyingMatrix, morphism_attr_1_1 ) );
+    return CreateCapCategoryObjectWithAttributes( cat_1, UnderlyingMorphism, CreateCapCategoryMorphismWithAttributes( deduped_2_1, CreateCapCategoryObjectWithAttributes( deduped_2_1, RankOfObject, NumberRows( deduped_1_1 ) ), CAP_JIT_INCOMPLETE_LOGIC( Range( UnderlyingMorphism( CAP_JIT_INCOMPLETE_LOGIC( objects_1[1] ) ) ) ), UnderlyingMatrix, deduped_1_1 ) );
 end
 ########
         


### PR DESCRIPTION
in CAP 2023.09-07

Note: I consider compiling code with `Iterated` with two arguments as deprecated. Currently there is no reason to remove support, but when I touch `CAP_JIT_INTERNAL_TELESCOPED_ITERATION` the next time I might have to drop it. I tried to reason about the current code in SliceCategory but ran into https://github.com/homalg-project/CategoricalTowers/issues/362 while doing so.