### PR TITLE
Use IsEqualForMorphisms for IsEqualForObjects in SliceCategory

### DIFF
--- a/SubcategoriesForCAP/PackageInfo.g
+++ b/SubcategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "SubcategoriesForCAP",
 Subtitle := "Subcategory and other related constructors for CAP categories",
-Version := "2023.09-02",
+Version := "2023.10-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/SubcategoriesForCAP/gap/SliceCategory.gi
+++ b/SubcategoriesForCAP/gap/SliceCategory.gi
@@ -292,7 +292,7 @@ BindGlobal( "CAP_INTERNAL_SLICE_CATEGORY",
         a_underlying := UnderlyingMorphism( a );
         b_underlying := UnderlyingMorphism( b );
         
-        return IsEqualForObjects( AmbientCategory( cat ), Source( a_underlying ), Source( b_underlying ) ) and IsCongruentForMorphisms( C, a_underlying, b_underlying );
+        return IsEqualForObjects( AmbientCategory( cat ), Source( a_underlying ), Source( b_underlying ) ) and IsEqualForMorphisms( C, a_underlying, b_underlying );
         
     end );
     


### PR DESCRIPTION
to match the technical equality expected by CompilerForCAP