### PR TITLE
relaxed condition for AddDerivationToCAP( ExactCoverWithGlobalElements, ... )

### DIFF
--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.11-09",
+Version := "2023.11-10",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2023.11-08",
+Version := "2023.11-09",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -3114,7 +3114,7 @@ InstallMethodForCompilerForCAP( MorphismFromRepresentableByYonedaLemma,
     d := DistinguishedObjectOfHomomorphismStructure( C );
     
     #% CAP_JIT_DROP_NEXT_STATEMENT
-    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( PSh ), H ) );
+    Assert( 0, IsIdenticalObj( RangeCategoryOfHomomorphismStructure( C ), H ) );
     
     Y := YonedaEmbeddingDataOfSourceCategory( PSh )[1];
     

--- a/FunctorCategories/gap/ToolsDerivedMethods.gi
+++ b/FunctorCategories/gap/ToolsDerivedMethods.gi
@@ -16,8 +16,11 @@ AddDerivationToCAP( ExactCoverWithGlobalElements,
     
 end :
   CategoryFilter := cat ->
+                    HasRangeCategoryOfHomomorphismStructure( cat ) and
+                    IsIdenticalObj( cat, RangeCategoryOfHomomorphismStructure( cat ) ) and
                     IsMatrixCategory( cat ) or
                     ( IsCategoryOfRows( cat ) and
                       HasCommutativeRingOfLinearCategory( cat ) and
-                      HasIsFieldForHomalg( CommutativeRingOfLinearCategory( cat ) ) and
-                      IsFieldForHomalg( CommutativeRingOfLinearCategory( cat ) ) ) );
+                      ## a commutative ring has the invariant basis property iff it is not the zero ring:
+                      HasHasInvariantBasisProperty( CommutativeRingOfLinearCategory( cat ) ) and
+                      HasInvariantBasisProperty( CommutativeRingOfLinearCategory( cat ) ) ) );


### PR DESCRIPTION
ExactCoverWithGlobalElements is need by MorphismFromRepresentableByYonedaLemma

These changes are suggested by @kamalsaleh