### PR TITLE
installed CoveringListOfRepresentables for the 2-enriched case

### DIFF
--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-12",
+Version := "2024.03-13",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
@@ -102,7 +102,7 @@ Dependencies := rec(
                    [ "FreydCategoriesForCAP", ">= 2024.01-03" ],
                    [ "SubcategoriesForCAP", ">= 2024.01-01" ],
                    [ "Toposes", ">= 2024.02-08" ],
-                   [ "Locales", ">= 2024.03-17" ],
+                   [ "Locales", ">= 2024.03-23" ],
                    [ "FinSetsForCAP", ">= 2024.02-09" ],
                    [ "ToolsForHigherHomologicalAlgebra", ">= 2023.03-01" ],
                    ],

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-11",
+Version := "2024.03-12",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-10",
+Version := "2024.03-11",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/doc/Doc.autodoc
+++ b/FunctorCategories/doc/Doc.autodoc
@@ -58,6 +58,10 @@
 
 @InsertChunk Weierstrass
 
+@Subsection Optimized co-Yoneda lemma for posets
+
+@InsertChunk OptimizedCoYoneda
+
 @Chapter Finite cocompletion of a finitely presented (linear) category
 
 @Section Constructors

--- a/FunctorCategories/examples/OptimizedCoYoneda.g
+++ b/FunctorCategories/examples/OptimizedCoYoneda.g
@@ -1,0 +1,51 @@
+#! @Chunk OptimizedCoYoneda
+
+#! @Example
+LoadPackage( "FunctorCategories", ">= 2024.03-13", false );
+#! true
+q := FinQuiver( "q(a,l,r,i,c,b)[ac:a->c,lc:l->c,ri:r->i,ic:i->c,cb:c->b]" );
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" )
+F := PathCategory( q );
+#! PathCategory(
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) )
+Size( F );
+#! 16
+P := PosetOfCategory( F );
+#! PosetOfCategory( PathCategory(
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) )
+Size( P );
+#! 16
+PSh := PreSheaves( P );
+#! PreSheaves( PosetOfCategory( PathCategory(
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) ),
+#! IntervalCategory )
+c := PSh.c;
+#! <A projective object in PreSheaves( PosetOfCategory( PathCategory(
+#!  FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) ),
+#!  IntervalCategory )>
+section :=
+  SectionFromOptimizedCoYonedaProjectiveObjectIntoCoYonedaProjectiveObject( c );
+#! <A split monomorphism in FiniteStrictCoproductCompletion(
+#!  PosetOfCategory( PathCategory(
+#!  FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) ) )>
+IsWellDefined( section );
+#! true
+IsIsomorphism( section );
+#! true
+Display( Source( section ) );
+#! [ 1, [ An object in the poset given by: (c) ] ]
+#! 
+#! An object in FiniteStrictCoproductCompletion( PosetOfCategory( PathCategory(
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) ) )
+#! given by the above data
+Display( Target( section ) );
+#! [ 5, [ An object in the poset given by: (a),
+#!        An object in the poset given by: (l),
+#!        An object in the poset given by: (r),
+#!        An object in the poset given by: (i),
+#!        An object in the poset given by: (c) ] ]
+#! 
+#! An object in FiniteStrictCoproductCompletion( PosetOfCategory( PathCategory(
+#! FinQuiver( "q(a,l,r,i,c,b)[ac:a-≻c,lc:l-≻c,ri:r-≻i,ic:i-≻c,cb:c-≻b]" ) ) ) )
+#! given by the above data
+#! @EndExample

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -354,10 +354,6 @@ DeclareAttribute( "CoveringListOfRepresentables",
         IsObjectInPreSheafCategory );
 
 #! @Arguments F
-DeclareAttribute( "DoctrineSpecificCoveringListOfRepresentables",
-        IsObjectInPreSheafCategory );
-
-#! @Arguments F
 DeclareAttribute( "CoveringListOfRepresentablesUsingSplits",
         IsObjectInPreSheafCategory );
 

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -2743,7 +2743,10 @@ InstallMethodForCompilerForCAP( ApplyObjectInPreSheafCategoryOfFpEnrichedCategor
         
     else
         
-        Error( "the type of the source category `B` is not supported yet\n" );
+        morB_op := MorphismConstructor( B_op,
+                           SetOfObjects( B_op )[SafeUniquePositionProperty( SetOfObjects( B ), obj -> IsEqualForObjects( B, obj, Target( morB ) ) )],
+                           morB,
+                           SetOfObjects( B_op )[SafeUniquePositionProperty( SetOfObjects( B ), obj -> IsEqualForObjects( B, obj, Source( morB ) ) )] );
         
     fi;
     

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -1456,7 +1456,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
           function( PSh, F )
             
             return MorphismFromCoproductOfRepresentables( PSh,
-                           DoctrineSpecificCoveringListOfRepresentables( D, PSh, F ),
+                           CoveringListOfRepresentables( D, PSh, F ),
                            F );
             
         end );
@@ -3307,17 +3307,16 @@ end );
 
 ##
 InstallOtherMethodForCompilerForCAP( CoveringListOfRepresentables,
-        [ IsPreSheafCategory, IsObjectInPreSheafCategory ],
+        [ IsSkeletalCategoryOfFiniteSets, IsPreSheafCategory, IsObjectInPreSheafCategory ],
         
-  function ( PSh, F )
-    local C, H, defining_triple, nr_objs, objs, homs, predicate, func, initial, cover, F_on_objs, embs, add_img_size, L;
+  function ( H, PSh, F )
+    local C, defining_triple, nr_objs, objs, homs, predicate, func, initial, cover, F_on_objs, embs, add_img_size, L;
     
     if IsInitial( PSh, F ) then
         return [ ];
     fi;
     
     C := Source( PSh );
-    H := Target( PSh );
     
     defining_triple := DefiningTripleOfUnderlyingQuiver( C );
     nr_objs := defining_triple[1];
@@ -3412,16 +3411,6 @@ InstallOtherMethodForCompilerForCAP( CoveringListOfRepresentables,
     L := List( L, L_o -> SortedList( L_o, {a,b} -> a[7] > b[7] ) );
     
     return Concatenation( L );
-    
-end );
-
-##
-InstallMethod( CoveringListOfRepresentables,
-        [ IsObjectInPreSheafCategory ],
-        
-  function ( F )
-    
-    return CoveringListOfRepresentables( CapCategory( F ), F );
     
 end );
 
@@ -3538,27 +3527,7 @@ InstallMethod( MaximalMorphismFromRepresentable,
 end );
 
 ##
-InstallOtherMethodForCompilerForCAP( DoctrineSpecificCoveringListOfRepresentables,
-        [ IsElementaryTopos, IsPreSheafCategory, IsObjectInPreSheafCategory ],
-        
-  function ( H, PSh, F )
-    
-    return CoveringListOfRepresentables( PSh, F );
-    
-end );
-
-##
-InstallOtherMethodForCompilerForCAP( DoctrineSpecificCoveringListOfRepresentables,
-        [ IsBooleanAlgebroid, IsPreSheafCategory, IsObjectInPreSheafCategory ],
-        
-  function ( H, PSh, F )
-    
-    return CoveringListOfRepresentables( PSh, F );
-    
-end );
-
-##
-InstallOtherMethodForCompilerForCAP( DoctrineSpecificCoveringListOfRepresentables,
+InstallOtherMethodForCompilerForCAP( CoveringListOfRepresentables,
         [ IsAbelianCategory, IsPreSheafCategory, IsObjectInPreSheafCategory ],
         
   function ( H, PSh, F )
@@ -3619,7 +3588,7 @@ InstallOtherMethodForCompilerForCAP( DoctrineSpecificCoveringListOfRepresentable
 end );
 
 ##
-InstallMethod( DoctrineSpecificCoveringListOfRepresentables,
+InstallMethod( CoveringListOfRepresentables,
         [ IsObjectInPreSheafCategory ],
         
   function ( F )
@@ -3627,7 +3596,7 @@ InstallMethod( DoctrineSpecificCoveringListOfRepresentables,
     
     PSh := CapCategory( F );
     
-    return DoctrineSpecificCoveringListOfRepresentables( Target( PSh ), PSh, F );
+    return CoveringListOfRepresentables( Target( PSh ), PSh, F );
     
 end );
 
@@ -3875,7 +3844,7 @@ InstallOtherMethodForCompilerForCAP( SectionFromOptimizedCoYonedaProjectiveObjec
   function ( PSh, F )
     
     return SectionAndComplementByCoveringListOfRepresentables( PSh,
-                   DoctrineSpecificCoveringListOfRepresentables( Target( PSh ), PSh, F ),
+                   CoveringListOfRepresentables( Target( PSh ), PSh, F ),
                    F )[1];
     
 end );
@@ -4051,7 +4020,7 @@ InstallOtherMethodForCompilerForCAP( RetractionFromCoYonedaProjectiveObjectOntoO
   function ( PSh, F )
     
     return RetractionByCoveringListOfRepresentables( Target( PSh ), PSh,
-                   DoctrineSpecificCoveringListOfRepresentables( Target( PSh ), PSh, F ),
+                   CoveringListOfRepresentables( Target( PSh ), PSh, F ),
                    F );
     
 end );

--- a/Locales/PackageInfo.g
+++ b/Locales/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2024.03-22",
+Version := "2024.03-23",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/Locales/PackageInfo.g
+++ b/Locales/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2024.03-21",
+Version := "2024.03-22",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/Locales/gap/Proset.gi
+++ b/Locales/gap/Proset.gi
@@ -65,6 +65,36 @@ InstallOtherMethod( Size,
 end );
 
 ##
+InstallOtherMethod( CapFunctor,
+        "for a thin category, two lists, and the interval category",
+        [ IsThinCategory and IsFiniteCategory, IsList, IsList, IsIntervalCategory ],
+        
+  function( P, imgs_of_objs, imgs_of_gmors, interval_category )
+    local F;
+    
+    F := CapFunctor( Concatenation( "Functor from ", Name( P ), " -> ", Name( interval_category ) ), P, interval_category );
+    
+    AddObjectFunction( F,
+      function ( obj )
+        
+        return imgs_of_objs[SafeUniquePositionProperty( SetOfObjects( P ), o -> IsEqualForObjects( P, o, obj ) )];
+        
+    end );
+    
+    AddMorphismFunction( F,
+      function ( F_s, mor, F_t )
+        
+        return UniqueMorphism( interval_category,
+                       F_s,
+                       F_t );
+        
+    end );
+    
+    return F;
+    
+end );
+
+##
 InstallMethod( Display,
         "for an object in a proset",
         [ IsMorphismInThinCategory ],

--- a/Locales/gap/ProsetDerivedMethods.gi
+++ b/Locales/gap/ProsetDerivedMethods.gi
@@ -244,9 +244,9 @@ AddDerivationToCAP( IsLiftableAlongMonomorphism,
         "IsLiftableAlongMonomorphism using IsHomSetInhabited",
         [ [ IsHomSetInhabited, 1 ] ],
         
-  function( cat, u1, u2 )
+  function( cat, mono, tau )
     
-    return IsHomSetInhabited( cat, Source( u1 ), Source( u2 ) );
+    return IsHomSetInhabited( cat, Source( tau ), Source( mono ) );
     
 end : CategoryFilter := IsThinCategory );
 

--- a/Locales/gap/ProsetDerivedMethods.gi
+++ b/Locales/gap/ProsetDerivedMethods.gi
@@ -255,10 +255,10 @@ AddDerivationToCAP( LiftAlongMonomorphism,
         "LiftAlongMonomorphism using the unique morphism from the source of the first argument to the source of the second",
         [ [ UniqueMorphism, 1 ] ],
         
-  function( cat, u1, u2 )
+  function( cat, mono, tau )
     
     ## the behavior of LiftAlongMonomorphism is unspecified on input violating the specification
-    return UniqueMorphism( cat, Source( u2 ), Source( u1 ) );
+    return UniqueMorphism( cat, Source( tau ), Source( mono ) );
     
 end : CategoryFilter := IsThinCategory );
 
@@ -267,9 +267,9 @@ AddDerivationToCAP( IsColiftableAlongEpimorphism,
         "IsColiftableAlongEpimorphism using IsHomSetInhabited",
         [ [ IsHomSetInhabited, 1 ] ],
         
-  function( cat, u1, u2 )
+  function( cat, epi, tau )
     
-    return IsHomSetInhabited( cat, Target( u1 ), Target( u2 ) );
+    return IsHomSetInhabited( cat, Target( epi ), Target( tau ) );
     
 end : CategoryFilter := IsThinCategory );
 
@@ -278,10 +278,10 @@ AddDerivationToCAP( ColiftAlongEpimorphism,
         "ColiftAlongEpimorphism using the unique morphism from the range of the second argument to the range of the first",
         [ [ UniqueMorphism, 1 ] ],
         
-  function( cat, u1, u2 )
+  function( cat, epi, tau )
     
     ## the behavior of ColiftAlongEpimorphism is unspecified on input violating the specification
-    return UniqueMorphism( cat, Target( u1 ), Target( u2 ) );
+    return UniqueMorphism( cat, Target( epi ), Target( tau ) );
     
 end : CategoryFilter := IsThinCategory );
 


### PR DESCRIPTION
* fixed AddDerivationToCAP( IsLiftableAlongMonomorphism, proset )
* installed CapFunctor for prosets
* enhanced ApplyObjectInPreSheafCategoryOfFpEnrichedCategoryToMorphism to support further source categories
