### PR TITLE
d&i AssociatedCoequalizerPairInPreSheaves

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-10",
+Version := "2024.03-11",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-08",
+Version := "2024.03-09",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-11",
+Version := "2024.03-12",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-09",
+Version := "2024.03-10",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-07",
+Version := "2024.03-08",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2024.03-12",
+Version := "2024.03-13",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
+++ b/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
@@ -52,10 +52,10 @@ Display( F );
 F_as_presheaf := ModelingObject( Chat, ModelingObject( FinBouquets, F ) );
 #! <An object in PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ),
 #!  SkeletalFinSets )>
-F_as_coequalizer_pair := CoYonedaLemmaOnObjects( F_as_presheaf );
+F_as_coequalizer_object := CoYonedaLemmaOnObjects( F_as_presheaf );
 #! <An object in FiniteColimitCompletionWithStrictCoproducts(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
-ColimitCompletionC := CapCategory( F_as_coequalizer_pair );
+ColimitCompletionC := CapCategory( F_as_coequalizer_object );
 #! FiniteColimitCompletionWithStrictCoproducts(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )
 Display( ColimitCompletionC );
@@ -68,7 +68,7 @@ Display( ColimitCompletionC );
 #! * IsCocartesianCategory
 #! and not yet algorithmically
 #! * IsFiniteCocompleteCategory
-Display( F_as_coequalizer_pair );
+Display( F_as_coequalizer_object );
 #! Image of <(V)>:
 #! [ 7, [ <(P)>, <(P)>, <(P)>, <(L)>, <(L)>, <(L)>, <(L)> ] ]
 #! 
@@ -103,7 +103,7 @@ Display( F_as_coequalizer_pair );
 #! 
 #! An object in FiniteColimitCompletionWithStrictCoproducts(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
-F_as_colimit_quiver := AssociatedColimitQuiver( F_as_coequalizer_pair );
+F_as_colimit_quiver := AssociatedColimitQuiver( F_as_coequalizer_object );
 #! <An object in CategoryOfColimitQuivers(
 #!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
 Display( F_as_colimit_quiver );

--- a/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
+++ b/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
@@ -1,7 +1,7 @@
 #! @BeginChunk CategoryOfColimitQuivers
 
 #! @Example
-LoadPackage( "FunctorCategories", ">= 2024.03-17", false );
+LoadPackage( "FunctorCategories", ">= 2024.03-18", false );
 #! true
 FinBouquets;
 #! FinBouquets
@@ -128,5 +128,8 @@ Display( F_as_colimit_quiver );
 #! 
 #! An object in CategoryOfColimitQuivers(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+F_as_presheaf =
+  Coequalizer( AssociatedCoequalizerPairInPreSheaves( F_as_colimit_quiver )[2] );
+#! true
 #! @EndExample
 #! @EndChunk

--- a/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
+++ b/FiniteCocompletions/examples/CategoryOfColimitQuivers.g
@@ -1,7 +1,7 @@
 #! @BeginChunk CategoryOfColimitQuivers
 
 #! @Example
-LoadPackage( "FunctorCategories", ">= 2023.11-07", false );
+LoadPackage( "FunctorCategories", ">= 2024.03-17", false );
 #! true
 FinBouquets;
 #! FinBouquets
@@ -52,6 +52,18 @@ Display( F );
 F_as_presheaf := ModelingObject( Chat, ModelingObject( FinBouquets, F ) );
 #! <An object in PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ),
 #!  SkeletalFinSets )>
+Display( F_as_presheaf );
+#! Image of <(P)>:
+#! { 0, 1, 2 }
+#! 
+#! Image of <(L)>:
+#! { 0,..., 3 }
+#! 
+#! Image of (P)-[(b)]->(L):
+#! { 0,..., 3 } ⱶ[ 0, 0, 0, 2 ]→ { 0, 1, 2 }
+#! 
+#! An object in PreSheaves( FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ),
+#! SkeletalFinSets ) given by the above data
 F_as_coequalizer_object := CoYonedaLemmaOnObjects( F_as_presheaf );
 #! <An object in FiniteColimitCompletionWithStrictCoproducts(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>
@@ -103,6 +115,9 @@ Display( F_as_coequalizer_object );
 #! 
 #! An object in FiniteColimitCompletionWithStrictCoproducts(
 #! FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) ) given by the above data
+F_as_presheaf =
+  Coequalizer( AssociatedCoequalizerPairInPreSheaves( F_as_coequalizer_object )[2] );
+#! true
 F_as_colimit_quiver := AssociatedColimitQuiver( F_as_coequalizer_object );
 #! <An object in CategoryOfColimitQuivers(
 #!  FreeCategory( RightQuiver( "q(P,L)[b:P->L]" ) ) )>

--- a/FiniteCocompletions/examples/FinReflexiveQuiversAsFiniteColimitCompletion.g
+++ b/FiniteCocompletions/examples/FinReflexiveQuiversAsFiniteColimitCompletion.g
@@ -81,7 +81,7 @@ Display( coeq_pair );
 IsWellDefined( coeq_pair );
 #! true
 coeq_pair_in_presheaves := CoYonedaLemmaCoequalizerPair( PSh.C1 );;
-coeq := Coequalizer( coeq_pair_in_presheaves[1], coeq_pair_in_presheaves[2] );
+coeq := Coequalizer( coeq_pair_in_presheaves[2] );
 #! <An object in PreSheaves( FreeCategory( RightQuiver(
 #!  "Delta(C0,C1)[id:C1->C0,s:C0->C1,t:C0->C1]" ) ) / [ s*id = C0, t*id = C0 ],
 #!  SkeletalFinSets )>

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
@@ -44,6 +44,29 @@ DeclareCategory( "IsMorphismInCategoryOfColimitQuivers",
 #
 ####################################
 
+#! @Description
+#!  Return the category $C$ underlying the category of colimit quivers
+#!  <A>ColimitQuivers</A> := <C>CategoryOfColimitQuivers</C>( $C$ ).
+#! @Arguments ColimitQuivers
+DeclareAttribute( "UnderlyingCategory",
+        IsCategoryOfColimitQuivers );
+
+CapJitAddTypeSignature( "UnderlyingCategory", [ IsCategoryOfColimitQuivers ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( UnderlyingCategory( input_types[1].category ) );
+    
+end );
+
+#! @Description
+#!  The full embedding functor from the category $C$ underlying
+#!  the category of colimit quivers
+#!  <A>ColimitQuivers</A> into <A>ColimitQuivers</A>.
+#! @Arguments ColimitQuivers
+#! @Returns a &CAP; functor
+DeclareAttribute( "EmbeddingOfUnderlyingCategory",
+        IsCategoryOfColimitQuivers );
+
 #! @Arguments colimit_quiver
 DeclareAttribute( "DefiningPairOfColimitQuiver",
         IsObjectInCategoryOfColimitQuivers );
@@ -109,26 +132,3 @@ DeclareOperation( "CreateColimitQuiver",
 #! @Returns a colimit quiver morphism
 DeclareOperation( "CreateMorphismOfColimitQuivers",
         [ IsObjectInCategoryOfColimitQuivers, IsList, IsObjectInCategoryOfColimitQuivers ] );
-
-#! @Description
-#!  Return the category $C$ underlying the category of colimit quivers
-#!  <A>ColimitQuivers</A> := <C>CategoryOfColimitQuivers</C>( $C$ ).
-#! @Arguments ColimitQuivers
-DeclareAttribute( "UnderlyingCategory",
-        IsCategoryOfColimitQuivers );
-
-CapJitAddTypeSignature( "UnderlyingCategory", [ IsCategoryOfColimitQuivers ],
-  function ( input_types )
-    
-    return CapJitDataTypeOfCategory( UnderlyingCategory( input_types[1].category ) );
-    
-end );
-
-#! @Description
-#!  The full embedding functor from the category $C$ underlying
-#!  the category of colimit quivers
-#!  <A>ColimitQuivers</A> into <A>ColimitQuivers</A>.
-#! @Arguments ColimitQuivers
-#! @Returns a &CAP; functor
-DeclareAttribute( "EmbeddingOfUnderlyingCategory",
-        IsCategoryOfColimitQuivers );

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
@@ -103,6 +103,21 @@ CapJitAddTypeSignature( "DefiningPairOfColimitQuiverMorphism", [ IsMorphismInCat
     
 end );
 
+#! @Description
+#!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ), return
+#!  the ambient category <C>CoequalizerCompletion</C>( <C>AssociatedFiniteStrictCoproductCompletionOfSourceCategory</C>( <A>PSh</A> ) ).
+#! @Arguments PSh
+#! @Returns a &CAP; category
+DeclareAttribute( "FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory",
+        IsCategoryOfColimitQuivers );
+
+CapJitAddTypeSignature( "FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory", [ IsCategoryOfColimitQuivers ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory( input_types[1].category ) );
+    
+end );
+
 ####################################
 #
 #! @Section Constructors

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gd
@@ -147,3 +147,18 @@ DeclareOperation( "CreateColimitQuiver",
 #! @Returns a colimit quiver morphism
 DeclareOperation( "CreateMorphismOfColimitQuivers",
         [ IsObjectInCategoryOfColimitQuivers, IsList, IsObjectInCategoryOfColimitQuivers ] );
+
+#! @Description
+#!  Given the category <A>ColimitQuiversC</A>=<C>CategoryOfColimitQuivers</C>( $C$ ) of colimit quivers
+#!  in a $V$-enriched category $C$, return the associated category <C>PreSheaves</C>( $C$, $V$ ) of presheaves.
+#! @Arguments ColimitQuiversC
+#! @Returns a &CAP; category
+DeclareAttribute( "CategoryOfPreSheavesOfUnderlyingCategory",
+        IsCategoryOfColimitQuivers );
+
+CapJitAddTypeSignature( "CategoryOfPreSheavesOfUnderlyingCategory", [ IsCategoryOfColimitQuivers ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( CategoryOfPreSheavesOfUnderlyingCategory( input_types[1].category ) );
+    
+end );

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
@@ -248,6 +248,7 @@ InstallMethod( CategoryOfColimitQuivers,
     Append( ColimitQuivers!.compiler_hints.category_attribute_names,
             [ "UnderlyingCategory",
               "FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory",
+              "CategoryOfPreSheavesOfUnderlyingCategory",
               ] );
     
     if ValueOption( "no_precompiled_code" ) <> true then
@@ -335,6 +336,16 @@ InstallMethod( FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory,
   function( ColimitQuiversC )
     
     return FiniteColimitCompletionWithStrictCoproducts( UnderlyingCategory( ColimitQuiversC ) );
+    
+end );
+
+##
+InstallMethod( CategoryOfPreSheavesOfUnderlyingCategory,
+        [ IsCategoryOfColimitQuivers ],
+        
+  function( ColimitQuiversC )
+    
+    return PreSheaves( UnderlyingCategory( ColimitQuiversC ) );
     
 end );
 

--- a/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
+++ b/FiniteCocompletions/gap/CategoryOfColimitQuivers.gi
@@ -247,6 +247,7 @@ InstallMethod( CategoryOfColimitQuivers,
     
     Append( ColimitQuivers!.compiler_hints.category_attribute_names,
             [ "UnderlyingCategory",
+              "FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory",
               ] );
     
     if ValueOption( "no_precompiled_code" ) <> true then
@@ -324,6 +325,16 @@ InstallMethod( \.,
     fi;
     
     return Yc;
+    
+end );
+
+##
+InstallMethod( FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory,
+        [ IsCategoryOfColimitQuivers ],
+        
+  function( ColimitQuiversC )
+    
+    return FiniteColimitCompletionWithStrictCoproducts( UnderlyingCategory( ColimitQuiversC ) );
     
 end );
 

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
@@ -144,6 +144,21 @@ DeclareOperation( "AsColimitCompletionMorphism",
         [ IsFiniteColimitCompletionWithStrictCoproducts, IsCapCategoryMorphism ] );
 
 #! @Description
+#!  Given the finite colimit completion category <A>C_hat</A>=<C>FiniteColimitCompletionWithStrictCoproducts</C>( $C$ )
+#!  of a $V$-enriched category $C$, return the associated category <C>PreSheaves</C>( $C$, $V$ ) of presheaves.
+#! @Arguments C_hat
+#! @Returns a &CAP; category
+DeclareAttribute( "CategoryOfPreSheavesOfUnderlyingCategory",
+        IsFiniteColimitCompletionWithStrictCoproducts );
+
+CapJitAddTypeSignature( "CategoryOfPreSheavesOfUnderlyingCategory", [ IsFiniteColimitCompletionWithStrictCoproducts ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( CategoryOfPreSheavesOfUnderlyingCategory( input_types[1].category ) );
+    
+end );
+
+#! @Description
 #!  The input is an object <A>coequalizer_object</A> in the category of finite colimit completion of a category.
 #!  The output is the corresponding colimit quiver.
 #! @Arguments coequalizer_object

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
@@ -108,6 +108,22 @@ CapJitAddTypeSignature( "DefiningPairOfMorphismBetweenCoequalizerPairs", [ IsMor
     
 end );
 
+#! @Description
+#!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ) return
+#!  the ambient category <C>CategoryOfColimitQuivers</C>( $C$ ), provided
+#!  $C$ is enriched over <C>SkeletalFinSets</C>.
+#! @Arguments PSh
+#! @Returns a &CAP; category
+DeclareAttribute( "CategoryOfColimitQuiversOfUnderlyingCategory",
+        IsFiniteColimitCompletionWithStrictCoproducts );
+
+CapJitAddTypeSignature( "CategoryOfColimitQuiversOfUnderlyingCategory", [ IsFiniteColimitCompletionWithStrictCoproducts ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( CategoryOfColimitQuiversOfUnderlyingCategory( input_types[1].category ) );
+    
+end );
+
 ####################################
 #
 #! @Section Constructors

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gd
@@ -128,9 +128,9 @@ DeclareOperation( "AsColimitCompletionMorphism",
         [ IsFiniteColimitCompletionWithStrictCoproducts, IsCapCategoryMorphism ] );
 
 #! @Description
-#!  The input is an object <A>coequalizer_pair</A> in the category of finite colimit completion of a category.
+#!  The input is an object <A>coequalizer_object</A> in the category of finite colimit completion of a category.
 #!  The output is the corresponding colimit quiver.
-#! @Arguments coequalizer_pair
+#! @Arguments coequalizer_object
 #! @Returns a colimit quiver
 DeclareAttribute( "AssociatedColimitQuiver",
         IsObjectInFiniteColimitCompletionWithStrictCoproducts );

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
@@ -317,12 +317,12 @@ InstallOtherMethodForCompilerForCAP( AssociatedColimitQuiver,
         "for the category of finite colimit completion of a category and an object therein",
         [ IsFiniteColimitCompletionWithStrictCoproducts, IsObjectInFiniteColimitCompletionWithStrictCoproducts, IsCategoryOfColimitQuivers ],
         
-  function( ColimitCompletionC, coequalizer_pair, ColimitQuiversC )
+  function( ColimitCompletionC, coequalizer_object, ColimitQuiversC )
     
     return ReinterpretationOfObject( ColimitQuiversC,
                    ObjectDatum( ModelingObject( ModelingCategory( ColimitCompletionC ),
                            ModelingObject( ColimitCompletionC,
-                                   coequalizer_pair ) ) ) );
+                                   coequalizer_object ) ) ) );
     
 end );
 
@@ -331,16 +331,16 @@ InstallMethod( AssociatedColimitQuiver,
         "for an object in the category of finite colimit completion of a category",
         [ IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
         
-  function( coequalizer_pair )
+  function( coequalizer_object )
     local ColimitCompletionC, C, ColimitQuiversC;
     
-    ColimitCompletionC := CapCategory( coequalizer_pair );
+    ColimitCompletionC := CapCategory( coequalizer_object );
     
     C := UnderlyingCategory( ColimitCompletionC );
     
     ColimitQuiversC := CategoryOfColimitQuivers( C );
     
-    return AssociatedColimitQuiver( ColimitCompletionC, coequalizer_pair, ColimitQuiversC );
+    return AssociatedColimitQuiver( ColimitCompletionC, coequalizer_object, ColimitQuiversC );
     
 end );
 

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
@@ -144,6 +144,7 @@ InstallMethod( FiniteColimitCompletionWithStrictCoproducts,
             [ "UnderlyingCategory",
               "FiniteStrictCoproductCompletionOfUnderlyingCategory",
               "CategoryOfColimitQuiversOfUnderlyingCategory",
+              "CategoryOfPreSheavesOfUnderlyingCategory",
               ] );
     
     if ValueOption( "no_precompiled_code" ) <> true then
@@ -320,6 +321,16 @@ InstallMethod( CategoryOfColimitQuiversOfUnderlyingCategory,
   function( C_hat )
     
     return CategoryOfColimitQuivers( UnderlyingCategory( C_hat ) );
+    
+end );
+
+##
+InstallMethod( CategoryOfPreSheavesOfUnderlyingCategory,
+        [ IsFiniteColimitCompletionWithStrictCoproducts ],
+        
+  function( C_hat )
+    
+    return PreSheaves( UnderlyingCategory( C_hat ) );
     
 end );
 

--- a/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
+++ b/FiniteCocompletions/gap/FiniteColimitCompletionWithStrictCoproducts.gi
@@ -143,6 +143,7 @@ InstallMethod( FiniteColimitCompletionWithStrictCoproducts,
     Append( ColimitCompletion!.compiler_hints.category_attribute_names,
             [ "UnderlyingCategory",
               "FiniteStrictCoproductCompletionOfUnderlyingCategory",
+              "CategoryOfColimitQuiversOfUnderlyingCategory",
               ] );
     
     if ValueOption( "no_precompiled_code" ) <> true then
@@ -313,16 +314,34 @@ InstallMethod( \.,
 end );
 
 ##
+InstallMethod( CategoryOfColimitQuiversOfUnderlyingCategory,
+        [ IsFiniteColimitCompletionWithStrictCoproducts ],
+        
+  function( C_hat )
+    
+    return CategoryOfColimitQuivers( UnderlyingCategory( C_hat ) );
+    
+end );
+
+##
 InstallOtherMethodForCompilerForCAP( AssociatedColimitQuiver,
         "for the category of finite colimit completion of a category and an object therein",
-        [ IsFiniteColimitCompletionWithStrictCoproducts, IsObjectInFiniteColimitCompletionWithStrictCoproducts, IsCategoryOfColimitQuivers ],
+        [ IsFiniteColimitCompletionWithStrictCoproducts, IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
         
-  function( ColimitCompletionC, coequalizer_object, ColimitQuiversC )
+  function( ColimitCompletionC, coequalizer_object )
+    local ColimitQuiversC, Coeq, Quot;
+    
+    ColimitQuiversC := CategoryOfColimitQuiversOfUnderlyingCategory( ColimitCompletionC );
+    
+    Coeq := ModelingCategory( ColimitCompletionC );
+    
+    Quot := ModelingCategory( Coeq );
     
     return ReinterpretationOfObject( ColimitQuiversC,
-                   ObjectDatum( ModelingObject( ModelingCategory( ColimitCompletionC ),
-                           ModelingObject( ColimitCompletionC,
-                                   coequalizer_object ) ) ) );
+                   ObjectDatum( Quot,
+                           ModelingObject( Coeq,
+                                   ModelingObject( ColimitCompletionC,
+                                           coequalizer_object ) ) ) );
     
 end );
 
@@ -332,15 +351,8 @@ InstallMethod( AssociatedColimitQuiver,
         [ IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
         
   function( coequalizer_object )
-    local ColimitCompletionC, C, ColimitQuiversC;
     
-    ColimitCompletionC := CapCategory( coequalizer_object );
-    
-    C := UnderlyingCategory( ColimitCompletionC );
-    
-    ColimitQuiversC := CategoryOfColimitQuivers( C );
-    
-    return AssociatedColimitQuiver( ColimitCompletionC, coequalizer_object, ColimitQuiversC );
+    return AssociatedColimitQuiver( CapCategory( coequalizer_object ), coequalizer_object );
     
 end );
 

--- a/FiniteCocompletions/gap/PairOfParallelArrowsCategory.gi
+++ b/FiniteCocompletions/gap/PairOfParallelArrowsCategory.gi
@@ -16,7 +16,7 @@ InstallMethod( PairOfParallelArrowsCategory,
   function ( C )
     local object_datum_type, object_constructor, object_datum,
           morphism_datum_type, morphism_constructor, morphism_datum,
-          F, PSh,
+          F, PSh_VA,
           modeling_tower_object_constructor, modeling_tower_object_datum,
           modeling_tower_morphism_constructor, modeling_tower_morphism_datum,
           ParallelPairs;
@@ -68,14 +68,14 @@ InstallMethod( PairOfParallelArrowsCategory,
     
     F := CategoryFromDataTables( F : set_category_attribute_resolving_functions := true, FinalizeCategory := true );
     
-    PSh := PreSheaves( F, C : FinalizeCategory := true );
+    PSh_VA := PreSheaves( F, C : FinalizeCategory := true );
     
     ## from the raw object data to the object in the modeling category
     modeling_tower_object_constructor :=
       function( ParallelPairs, pair_of_pairs )
-        local PSh, A, V, s, t;
+        local PSh_VA, A, V, s, t;
         
-        PSh := ModelingCategory( ParallelPairs );
+        PSh_VA := ModelingCategory( ParallelPairs );
         
         V := pair_of_pairs[1][1];
         A := pair_of_pairs[1][2];
@@ -83,19 +83,19 @@ InstallMethod( PairOfParallelArrowsCategory,
         s := pair_of_pairs[2][1];
         t := pair_of_pairs[2][2];
         
-        return ObjectConstructor( PSh, Pair( [ V, A ], [ s, t ] ) );
+        return ObjectConstructor( PSh_VA, Pair( [ V, A ], [ s, t ] ) );
         
     end;
     
     ## from the object in the modeling category to the raw object data
     modeling_tower_object_datum :=
       function( ParallelPairs, obj )
-        local PSh, VAst, VA, st;
+        local PSh_VA, VAst, VA, st;
         
-        PSh := ModelingCategory( ParallelPairs );
+        PSh_VA := ModelingCategory( ParallelPairs );
         
         ## Pair( [ V, A ], [ s, t ] )
-        VAst := ObjectDatum( PSh, obj );
+        VAst := ObjectDatum( PSh_VA, obj );
         
         VA := VAst[1];
         st := VAst[2];
@@ -108,14 +108,14 @@ InstallMethod( PairOfParallelArrowsCategory,
     ## from the raw morphism data to the morphism in the modeling category
     modeling_tower_morphism_constructor :=
       function( ParallelPairs, source, pair, target )
-        local PSh, V, A;
+        local PSh_VA, V, A;
         
-        PSh := ModelingCategory( ParallelPairs );
+        PSh_VA := ModelingCategory( ParallelPairs );
         
         V := pair[1];
         A := pair[2];
         
-        return MorphismConstructor( PSh,
+        return MorphismConstructor( PSh_VA,
                        source,
                        [ V, A ], ## convert from pair to list for CompilerForCAP
                        target );
@@ -125,11 +125,11 @@ InstallMethod( PairOfParallelArrowsCategory,
     ## from the morphism in the modeling category to the raw morphism data
     modeling_tower_morphism_datum :=
       function( ParallelPairs, mor )
-        local PSh, mor_datum;
+        local PSh_VA, mor_datum;
         
-        PSh := ModelingCategory( ParallelPairs );
+        PSh_VA := ModelingCategory( ParallelPairs );
         
-        mor_datum := MorphismDatum( PSh, mor );
+        mor_datum := MorphismDatum( PSh_VA, mor );
         
         return Pair( mor_datum[1], mor_datum[2] ); ## convert from list to pair for CompilerForCAP
         
@@ -140,7 +140,7 @@ InstallMethod( PairOfParallelArrowsCategory,
     ## after compilation the tower is gone and the only reminiscent which hints to the tower
     ## is the attribute ModelingCategory:
     ParallelPairs :=
-      ReinterpretationOfCategory( PSh,
+      ReinterpretationOfCategory( PSh_VA,
               rec( name := Concatenation( "PairOfParallelArrowsCategory( ", Name( C ), " )" ),
                    category_filter := IsPairOfParallelArrowsCategory,
                    category_object_filter := IsObjectInPairOfParallelArrowsCategory,

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-14",
+Version := "2024.03-15",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-15",
+Version := "2024.03-16",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-13",
+Version := "2024.03-14",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-17",
+Version := "2024.03-18",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
@@ -95,7 +95,7 @@ Dependencies := rec(
                    [ "ToolsForCategoricalTowers", ">= 2024.03-02" ],
                    [ "FpCategories", ">= 2024.03-03" ],
                    [ "Algebroids", ">= 2024.03-01" ],
-                   [ "FiniteCocompletions", ">= 2024.03-10" ],
+                   [ "FiniteCocompletions", ">= 2024.03-12" ],
                    [ "PreSheaves", ">= 2024.02-02" ],
                    [ "RingsForHomalg", ">= 2020.02.04" ],
                    [ "LinearAlgebraForCAP", ">= 2024.01-04" ],

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2024.03-16",
+Version := "2024.03-17",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
@@ -95,7 +95,7 @@ Dependencies := rec(
                    [ "ToolsForCategoricalTowers", ">= 2024.03-02" ],
                    [ "FpCategories", ">= 2024.03-03" ],
                    [ "Algebroids", ">= 2024.03-01" ],
-                   [ "FiniteCocompletions", ">= 2024.03-04" ],
+                   [ "FiniteCocompletions", ">= 2024.03-10" ],
                    [ "PreSheaves", ">= 2024.02-02" ],
                    [ "RingsForHomalg", ">= 2020.02.04" ],
                    [ "LinearAlgebraForCAP", ">= 2024.01-04" ],

--- a/FunctorCategories/gap/HomStructure.gi
+++ b/FunctorCategories/gap/HomStructure.gi
@@ -48,7 +48,7 @@ InstallMethodForCompilerForCAP( ExternalHomOnMorphismsEqualizerFunctorialDataUsi
         
   function ( PSh, eta, rho )
     local colimit_completion_C, UC, F, G,
-          eta_coequalizer_pair_morphism, eta_coequalizer_pair_as_presheaf_morphism_datum,
+          eta_coequalizer_object_morphism, eta_coequalizer_object_as_presheaf_morphism_datum,
           S, eta_V_S, F_data, F_V, F_V_data, diagram_F_V_S, T, diagram_F_V_T, D, F_V_rho;
     
     colimit_completion_C := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
@@ -58,16 +58,16 @@ InstallMethodForCompilerForCAP( ExternalHomOnMorphismsEqualizerFunctorialDataUsi
     F := Source( eta );
     G := Target( eta );
     
-    eta_coequalizer_pair_morphism := CoYonedaLemmaOnMorphisms( PSh,
-                                             CoYonedaLemmaOnObjects( PSh, F ),
-                                             eta,
-                                             CoYonedaLemmaOnObjects( PSh, G ) );
+    eta_coequalizer_object_morphism := CoYonedaLemmaOnMorphisms( PSh,
+                                               CoYonedaLemmaOnObjects( PSh, F ),
+                                               eta,
+                                               CoYonedaLemmaOnObjects( PSh, G ) );
     
-    eta_coequalizer_pair_as_presheaf_morphism_datum := MorphismDatum( colimit_completion_C, eta_coequalizer_pair_morphism );
+    eta_coequalizer_object_as_presheaf_morphism_datum := MorphismDatum( colimit_completion_C, eta_coequalizer_object_morphism );
     
     S := Source( rho );
     
-    eta_V_S := ApplyPreSheafToMorphismInFiniteStrictCoproductCompletion( PSh, S, eta_coequalizer_pair_as_presheaf_morphism_datum[1] );
+    eta_V_S := ApplyPreSheafToMorphismInFiniteStrictCoproductCompletion( PSh, S, eta_coequalizer_object_as_presheaf_morphism_datum[1] );
     
     F_data := CoequalizerDataOfPreSheafUsingCoYonedaLemma( PSh, F );
     

--- a/FunctorCategories/gap/HomStructure.gi
+++ b/FunctorCategories/gap/HomStructure.gi
@@ -51,7 +51,7 @@ InstallMethodForCompilerForCAP( ExternalHomOnMorphismsEqualizerFunctorialDataUsi
           eta_coequalizer_object_morphism, eta_coequalizer_object_as_presheaf_morphism_datum,
           S, eta_V_S, F_data, F_V, F_V_data, diagram_F_V_S, T, diagram_F_V_T, D, F_V_rho;
     
-    colimit_completion_C := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    colimit_completion_C := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     UC := FiniteStrictCoproductCompletionOfUnderlyingCategory( colimit_completion_C );
     

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -156,10 +156,10 @@ end );
 #!  the ambient category <C>CoequalizerCompletion</C>( <C>FiniteStrictCoproductCompletionOfSourceCategory</C>( <A>PSh</A> ) ).
 #! @Arguments PSh
 #! @Returns a &CAP; category
-DeclareAttribute( "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory",
+DeclareAttribute( "FiniteColimitCompletionWithStrictCoproductsOfSourceCategory",
         IsPreSheafCategory );
 
-CapJitAddTypeSignature( "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory", [ IsPreSheafCategory ],
+CapJitAddTypeSignature( "FiniteColimitCompletionWithStrictCoproductsOfSourceCategory", [ IsPreSheafCategory ],
   function ( input_types )
     
     return CapJitDataTypeOfCategory( FiniteColimitCompletionWithStrictCoproducts( Source( input_types[1].category ) ) );

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -141,10 +141,10 @@ DeclareAttribute( "SievesOfPathsToTruth", IsMorphismInPreSheafCategory );
 #!  the "sub"category <C>EnrichmentSpecificFiniteStrictCoproductCompletion</C>( $C$ ).
 #! @Arguments PSh
 #! @Returns a &CAP; category
-DeclareAttribute( "AssociatedFiniteStrictCoproductCompletionOfSourceCategory",
+DeclareAttribute( "FiniteStrictCoproductCompletionOfSourceCategory",
         IsPreSheafCategory );
 
-CapJitAddTypeSignature( "AssociatedFiniteStrictCoproductCompletionOfSourceCategory", [ IsPreSheafCategory ],
+CapJitAddTypeSignature( "FiniteStrictCoproductCompletionOfSourceCategory", [ IsPreSheafCategory ],
   function ( input_types )
     
     return CapJitDataTypeOfCategory( EnrichmentSpecificFiniteStrictCoproductCompletion( Source( input_types[1].category ) ) );
@@ -153,7 +153,7 @@ end );
 
 #! @Description
 #!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ), return
-#!  the ambient category <C>CoequalizerCompletion</C>( <C>AssociatedFiniteStrictCoproductCompletionOfSourceCategory</C>( <A>PSh</A> ) ).
+#!  the ambient category <C>CoequalizerCompletion</C>( <C>FiniteStrictCoproductCompletionOfSourceCategory</C>( <A>PSh</A> ) ).
 #! @Arguments PSh
 #! @Returns a &CAP; category
 DeclareAttribute( "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory",

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -391,6 +391,10 @@ DeclareAttribute( "CoequalizerDataOfPreSheafUsingOptimizedCoYonedaLemma",
 
 #! @Arguments F
 DeclareAttribute( "AssociatedCoequalizerPairInPreSheaves",
+        IsObjectInCategoryOfColimitQuivers );
+
+#! @Arguments F
+DeclareAttribute( "AssociatedCoequalizerPairInPreSheaves",
         IsObjectInFiniteColimitCompletionWithStrictCoproducts );
 
 #! @Arguments F

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -390,6 +390,10 @@ DeclareAttribute( "CoequalizerDataOfPreSheafUsingOptimizedCoYonedaLemma",
         IsObjectInPreSheafCategory );
 
 #! @Arguments F
+DeclareAttribute( "AssociatedCoequalizerPairInPreSheaves",
+        IsObjectInFiniteColimitCompletionWithStrictCoproducts );
+
+#! @Arguments F
 DeclareAttribute( "OptimizedCoYonedaLemmaCoequalizerPair",
         IsObjectInPreSheafCategory );
 

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -137,7 +137,7 @@ DeclareAttribute( "NerveTruncatedInDegree2", IsCapCategory );
 DeclareAttribute( "SievesOfPathsToTruth", IsMorphismInPreSheafCategory );
 
 #! @Description
-#!  Given the presheaf category <A>PSh</A>=<C>PSh</C>($C,V$) return
+#!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ), return
 #!  the "sub"category <C>EnrichmentSpecificFiniteStrictCoproductCompletion</C>( $C$ ).
 #! @Arguments PSh
 #! @Returns a &CAP; category
@@ -152,7 +152,7 @@ CapJitAddTypeSignature( "AssociatedFiniteStrictCoproductCompletionOfSourceCatego
 end );
 
 #! @Description
-#!  Given the presheaf category <A>PSh</A>=<C>PSh</C>($C,V$) return
+#!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ), return
 #!  the ambient category <C>CoequalizerCompletion</C>( <C>AssociatedFiniteStrictCoproductCompletionOfSourceCategory</C>( <A>PSh</A> ) ).
 #! @Arguments PSh
 #! @Returns a &CAP; category
@@ -167,7 +167,7 @@ CapJitAddTypeSignature( "AssociatedFiniteColimitCompletionWithStrictCoproductsOf
 end );
 
 #! @Description
-#!  Given the presheaf category <A>PSh</A>=<C>PSh</C>($C,V$) return
+#!  Given the presheaf category <A>PSh</A>=<C>PreSheaves</C>( $C$, $V$ ) return
 #!  the ambient category <C>CategoryOfColimitQuivers</C>( $C$ ), provided
 #!  $C$ is enriched over <C>SkeletalFinSets</C>.
 #! @Arguments PSh

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -172,10 +172,10 @@ end );
 #!  $C$ is enriched over <C>SkeletalFinSets</C>.
 #! @Arguments PSh
 #! @Returns a &CAP; category
-DeclareAttribute( "AssociatedCategoryOfColimitQuiversOfSourceCategory",
+DeclareAttribute( "CategoryOfColimitQuiversOfSourceCategory",
         IsPreSheafCategory );
 
-CapJitAddTypeSignature( "AssociatedCategoryOfColimitQuiversOfSourceCategory", [ IsPreSheafCategory ],
+CapJitAddTypeSignature( "CategoryOfColimitQuiversOfSourceCategory", [ IsPreSheafCategory ],
   function ( input_types )
     
     return CapJitDataTypeOfCategory( CategoryOfColimitQuivers( Source( input_types[1].category ) ) );

--- a/FunctorCategories/gap/PreSheaves.gd
+++ b/FunctorCategories/gap/PreSheaves.gd
@@ -162,7 +162,7 @@ DeclareAttribute( "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSource
 CapJitAddTypeSignature( "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory", [ IsPreSheafCategory ],
   function ( input_types )
     
-    return CapJitDataTypeOfCategory( CoequalizerCompletion( AssociatedFiniteStrictCoproductCompletionOfSourceCategory( input_types[1].category ) ) );
+    return CapJitDataTypeOfCategory( FiniteColimitCompletionWithStrictCoproducts( Source( input_types[1].category ) ) );
     
 end );
 

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -3196,6 +3196,51 @@ end );
 
 ##
 InstallOtherMethodForCompilerForCAP( AssociatedCoequalizerPairInPreSheaves,
+        "for a category of colimit quivers and an object therein",
+        [ IsCategoryOfColimitQuivers, IsObjectInCategoryOfColimitQuivers ],
+        
+  function( ColimitQuiversC, colimit_quiver )
+    local ParallelPairs, PSh_VA, F_VAst, V, A, s, t, PSh, Yoneda, Y_V, Y_A;
+    
+    ParallelPairs := ModelingCategory( ColimitQuiversC );
+    
+    PSh_VA := ModelingCategory( ParallelPairs );
+    
+    F_VAst := ObjectDatum( PSh_VA,
+                      ModelingObject( ParallelPairs,
+                              ModelingObject( ColimitQuiversC, colimit_quiver ) ) );
+    
+    V := F_VAst[1][1];
+    A := F_VAst[1][2];
+    s := F_VAst[2][1];
+    t := F_VAst[2][2];
+    
+    PSh := CategoryOfPreSheavesOfUnderlyingCategory( ColimitQuiversC );
+    
+    Yoneda := EmbeddingFunctorOfFiniteStrictCoproductCompletionIntoPreSheavesData( PSh )[2];
+    
+    Y_V := Yoneda[1]( V );
+    Y_A := Yoneda[1]( A );
+    
+    return Pair( Y_V,
+                 Pair( Yoneda[2]( Y_A, s, Y_V ),
+                       Yoneda[2]( Y_A, t, Y_V ) ) );
+    
+end );
+
+##
+InstallMethod( AssociatedCoequalizerPairInPreSheaves,
+        "for a colimit quiver in a category",
+        [ IsObjectInCategoryOfColimitQuivers ],
+        
+  function ( F )
+    
+    return AssociatedCoequalizerPairInPreSheaves( CapCategory( F ), F );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( AssociatedCoequalizerPairInPreSheaves,
         "for the finite colimit completion of a category and an object therein",
         [ IsFiniteColimitCompletionWithStrictCoproducts, IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
         

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -1308,7 +1308,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
             
             Append( PSh!.compiler_hints.category_attribute_names,
                     [ "FiniteStrictCoproductCompletionOfSourceCategory",
-                      "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory",
+                      "FiniteColimitCompletionWithStrictCoproductsOfSourceCategory",
                       ] );
             
             if not (HasIsAbCategory and IsAbCategory)( B ) then
@@ -2395,7 +2395,7 @@ InstallMethod( FiniteStrictCoproductCompletionOfSourceCategory,
 end );
 
 ##
-InstallMethod( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory,
+InstallMethod( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory,
         [ IsPreSheafCategory ],
         
   function( PSh )
@@ -2964,7 +2964,7 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaOnObjects,
                  V_list_of_objects_in_UC,
                  V );
     
-    C_hat := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    C_hat := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     return ObjectConstructor( C_hat,
                    Pair( Pair( V, A ), Pair( s, t ) ) );
@@ -3022,7 +3022,7 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaOnMorphisms,
     
     UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
-    C_hat := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    C_hat := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     coYo_F_VA := ObjectDatum( C_hat, source )[1];
     coYo_G_VA := ObjectDatum( C_hat, range )[1];
@@ -3145,7 +3145,7 @@ InstallOtherMethodForCompilerForCAP( CoequalizerDataOfPreSheafUsingCoYonedaLemma
   function ( PSh, F )
     local F_VAst;
     
-    F_VAst := ObjectDatum( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), CoYonedaLemmaOnObjects( PSh, F ) );
+    F_VAst := ObjectDatum( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), CoYonedaLemmaOnObjects( PSh, F ) );
     
     return Pair( F_VAst[1][1],
                  [ F_VAst[2][1], F_VAst[2][2] ] ); ## turn the pair F_VAst[2] into a list
@@ -3201,7 +3201,7 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaCoequalizerPair,
   function ( PSh, F )
     local F_VAst, V, A, s, t, Yoneda, Y_V, Y_A;
     
-    F_VAst := ObjectDatum( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), CoYonedaLemmaOnObjects( PSh, F ) );
+    F_VAst := ObjectDatum( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), CoYonedaLemmaOnObjects( PSh, F ) );
     
     V := F_VAst[1][1];
     A := F_VAst[1][2];
@@ -3975,7 +3975,7 @@ InstallOtherMethodForCompilerForCAP( RetractionByCoveringListOfRepresentables,
           section_complement, section, complement, summands, iso, inv,
           lift_on_O, lift_on_complement, lift, map, mor, lift_t_idV, retraction;
     
-    CoequalizerPairs := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    CoequalizerPairs := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
@@ -4066,7 +4066,7 @@ InstallOtherMethodForCompilerForCAP( RetractionByCoveringListOfRepresentables,
     local CoequalizerPairs, UC, coYoneda, F_VAst, V, A, s, t,
           section_complement, section, complement, summands, iso, inv, O, O_A, alpha, lift, retraction;
     
-    CoequalizerPairs := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    CoequalizerPairs := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
@@ -4152,7 +4152,7 @@ InstallOtherMethodForCompilerForCAP( OptimizedCoYonedaLemmaOnObjects,
    function ( PSh, F )
     local ColimitCompletionC, UC, F_VAst, H, retraction;
     
-    ColimitCompletionC := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    ColimitCompletionC := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
     UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
@@ -4186,7 +4186,7 @@ InstallOtherMethodForCompilerForCAP( CoequalizerDataOfPreSheafUsingOptimizedCoYo
   function ( PSh, F )
     local F_VAst;
     
-    F_VAst := ObjectDatum( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), OptimizedCoYonedaLemmaOnObjects( PSh, F ) );
+    F_VAst := ObjectDatum( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), OptimizedCoYonedaLemmaOnObjects( PSh, F ) );
     
     return Pair( F_VAst[1][1],
                  [ F_VAst[2][1], F_VAst[2][2] ] ); ## turn the pair F_VAst[2] into a list for Coequalizer
@@ -4210,7 +4210,7 @@ InstallOtherMethodForCompilerForCAP( OptimizedCoYonedaLemmaCoequalizerPair,
   function ( PSh, F )
     local F_VAst, V, A, s, t, Yoneda, Y_V, Y_A;
     
-    F_VAst := ObjectDatum( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), OptimizedCoYonedaLemmaOnObjects( PSh, F ) );
+    F_VAst := ObjectDatum( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), OptimizedCoYonedaLemmaOnObjects( PSh, F ) );
     
     V := F_VAst[1][1];
     A := F_VAst[1][2];

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -1313,7 +1313,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
             
             if not (HasIsAbCategory and IsAbCategory)( B ) then
                 Append( PSh!.compiler_hints.category_attribute_names,
-                    [ "AssociatedCategoryOfColimitQuiversOfSourceCategory",
+                    [ "CategoryOfColimitQuiversOfSourceCategory",
                       ] );
             fi;
             
@@ -2405,7 +2405,7 @@ InstallMethod( AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCate
 end );
 
 ##
-InstallMethod( AssociatedCategoryOfColimitQuiversOfSourceCategory,
+InstallMethod( CategoryOfColimitQuiversOfSourceCategory,
         [ IsPreSheafCategory ],
         
   function( PSh )

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -1307,7 +1307,7 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
             end );
             
             Append( PSh!.compiler_hints.category_attribute_names,
-                    [ "AssociatedFiniteStrictCoproductCompletionOfSourceCategory",
+                    [ "FiniteStrictCoproductCompletionOfSourceCategory",
                       "AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory",
                       ] );
             
@@ -2385,7 +2385,7 @@ InstallMethod( PreSheaves,
 end );
 
 ##
-InstallMethod( AssociatedFiniteStrictCoproductCompletionOfSourceCategory,
+InstallMethod( FiniteStrictCoproductCompletionOfSourceCategory,
         [ IsPreSheafCategory ],
         
   function( PSh )
@@ -2885,7 +2885,7 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaOnObjects,
     objs := SetOfObjects( C );
     mors := SetOfGeneratingMorphisms( C );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     F_vals := ValuesOfPreSheaf( F );
     
@@ -3020,7 +3020,7 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaOnMorphisms,
     F_vals := ValuesOfPreSheaf( F );
     G_vals := ValuesOfPreSheaf( G );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     C_hat := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
@@ -3169,7 +3169,7 @@ InstallMethodForCompilerForCAP( EmbeddingFunctorOfFiniteStrictCoproductCompletio
   function ( PSh )
     local UC;
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     return ExtendFunctorToFiniteStrictCoproductCompletionData( UC, YonedaEmbeddingDataOfSourceCategory( PSh ), PSh );
     
@@ -3844,7 +3844,7 @@ InstallOtherMethodForCompilerForCAP( SectionAndComplementByCoveringListOfReprese
     
     objs := SetOfObjects( C );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     F_on_objs := ObjectDatum( PSh, F )[1];
     
@@ -3977,7 +3977,7 @@ InstallOtherMethodForCompilerForCAP( RetractionByCoveringListOfRepresentables,
     
     CoequalizerPairs := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     coYoF := CoYonedaLemmaOnObjects( PSh, F );
     
@@ -4068,7 +4068,7 @@ InstallOtherMethodForCompilerForCAP( RetractionByCoveringListOfRepresentables,
     
     CoequalizerPairs := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     coYoneda := CoYonedaLemmaOnObjects( PSh, F );
     
@@ -4154,7 +4154,7 @@ InstallOtherMethodForCompilerForCAP( OptimizedCoYonedaLemmaOnObjects,
     
     ColimitCompletionC := AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     F_VAst := ObjectDatum( ColimitCompletionC, CoYonedaLemmaOnObjects( PSh, F ) );
     
@@ -4249,7 +4249,7 @@ InstallMethodForCompilerForCAP( ApplyPreSheafToObjectInFiniteStrictCoproductComp
     ## this code should be produced by something similar to ExtendFunctorToFiniteStrictProductCompletion:
     ## Apply Hom(-,G) to an object (in UC)
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     object_data := ObjectDatum( UC, object );
     
@@ -4269,7 +4269,7 @@ InstallMethodForCompilerForCAP( ApplyPreSheafToMorphismInFiniteStrictCoproductCo
     ## this code should be produced by something similar to ExtendFunctorToFiniteStrictProductCompletion:
     ## Apply Hom(-,G) to a morphism (in UC)
     
-    UC := AssociatedFiniteStrictCoproductCompletionOfSourceCategory( PSh );
+    UC := FiniteStrictCoproductCompletionOfSourceCategory( PSh );
     
     G_on_source_diagram := ApplyPreSheafToObjectInFiniteStrictCoproductCompletion( PSh, G, Source( morphism ) );
     G_on_range_diagram := ApplyPreSheafToObjectInFiniteStrictCoproductCompletion( PSh, G, Target( morphism ) );

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -3195,18 +3195,21 @@ InstallMethod( EmbeddingFunctorOfFiniteStrictCoproductCompletionIntoPreSheaves,
 end );
 
 ##
-InstallOtherMethodForCompilerForCAP( CoYonedaLemmaCoequalizerPair,
-        [ IsPreSheafCategoryOfFpEnrichedCategory, IsObjectInPreSheafCategoryOfFpEnrichedCategory ],
+InstallOtherMethodForCompilerForCAP( AssociatedCoequalizerPairInPreSheaves,
+        "for the finite colimit completion of a category and an object therein",
+        [ IsFiniteColimitCompletionWithStrictCoproducts, IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
         
-  function ( PSh, F )
-    local F_VAst, V, A, s, t, Yoneda, Y_V, Y_A;
+  function( C_hat, coequalizer_object )
+    local F_VAst, V, A, s, t, PSh, Yoneda, Y_V, Y_A;
     
-    F_VAst := ObjectDatum( FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh ), CoYonedaLemmaOnObjects( PSh, F ) );
+    F_VAst := ObjectDatum( C_hat, coequalizer_object );
     
     V := F_VAst[1][1];
     A := F_VAst[1][2];
     s := F_VAst[2][1];
     t := F_VAst[2][2];
+    
+    PSh := CategoryOfPreSheavesOfUnderlyingCategory( C_hat );
     
     Yoneda := EmbeddingFunctorOfFiniteStrictCoproductCompletionIntoPreSheavesData( PSh )[2];
     
@@ -3216,6 +3219,30 @@ InstallOtherMethodForCompilerForCAP( CoYonedaLemmaCoequalizerPair,
     return Pair( Y_V,
                  Pair( Yoneda[2]( Y_A, s, Y_V ),
                        Yoneda[2]( Y_A, t, Y_V ) ) );
+    
+end );
+
+##
+InstallMethod( AssociatedCoequalizerPairInPreSheaves,
+        "for an object in the finite colimit completion of a category",
+        [ IsObjectInFiniteColimitCompletionWithStrictCoproducts ],
+        
+  function( coequalizer_object )
+    
+    return AssociatedCoequalizerPairInPreSheaves( CapCategory( coequalizer_object ), coequalizer_object );
+    
+end );
+
+##
+InstallOtherMethodForCompilerForCAP( CoYonedaLemmaCoequalizerPair,
+        [ IsPreSheafCategoryOfFpEnrichedCategory, IsObjectInPreSheafCategoryOfFpEnrichedCategory ],
+        
+  function ( PSh, F )
+    local C_hat;
+    
+    C_hat := FiniteColimitCompletionWithStrictCoproductsOfSourceCategory( PSh );
+    
+    return AssociatedCoequalizerPairInPreSheaves( C_hat, CoYonedaLemmaOnObjects( PSh, F ) );
     
 end );
 


### PR DESCRIPTION
* renamed AssociatedFiniteStrictCoproductCompletionOfSourceCategory -> FiniteStrictCoproductCompletionOfSourceCategory
* renamed AssociatedCategoryOfColimitQuiversOfSourceCategory -> CategoryOfColimitQuiversOfSourceCategory
* renamed AssociatedFiniteColimitCompletionWithStrictCoproductsOfSourceCategory -> FiniteColimitCompletionWithStrictCoproductsOfSourceCategory
* d&i FiniteColimitCompletionWithStrictCoproductsOfUnderlyingCategory
* d&i CategoryOfColimitQuiversOfUnderlyingCategory and used it to simplify AssociatedColimitQuiver
* d&i CategoryOfPreSheavesOfUnderlyingCategory for IsFiniteColimitCompletionWithStrictCoproducts
* d&i AssociatedCoequalizerPairInPreSheaves and used it to simplify CoYonedaLemmaCoequalizerPair
* d&i CategoryOfPreSheavesOfUnderlyingCategory for IsCategoryOfColimitQuivers
* d&i AssociatedCoequalizerPairInPreSheaves for IsObjectInCategoryOfColimitQuivers
