### PR TITLE
do not let CategoryConstructor install certain operations for thin categories

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2025.02-02",
+Version := "2025.02-03",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/FiniteCocompletions/gap/FiniteStrictCoproductCompletion.gi
+++ b/FiniteCocompletions/gap/FiniteStrictCoproductCompletion.gi
@@ -229,29 +229,33 @@ InstallMethod( FiniteStrictCoproductCompletion,
         return ForAll( [ 1 .. Length( m1 ) ], i -> IsEqualForMorphisms( C, m1[i], m2[i] ) );
         
     end );
-    
-    ##
-    AddIsCongruentForMorphisms( UC,
-      function ( UC, morphism1, morphism2 )
-        local pair_of_lists1, pair_of_lists2, C, m1, m2;
+
+    if not ( IsBound( H ) and IsIntervalCategory( H ) ) then
         
-        pair_of_lists1 := MorphismDatum( UC, morphism1 );
-        pair_of_lists2 := MorphismDatum( UC, morphism2 );
+        ##
+        AddIsCongruentForMorphisms( UC,
+          function ( UC, morphism1, morphism2 )
+            local pair_of_lists1, pair_of_lists2, C, m1, m2;
+            
+            pair_of_lists1 := MorphismDatum( UC, morphism1 );
+            pair_of_lists2 := MorphismDatum( UC, morphism2 );
+            
+            ## SkeletalFinSets code:
+            if not pair_of_lists1[1] = pair_of_lists2[1] then
+                return false;
+            fi;
+            
+            ## FiniteStrictCoproductCompletion code:
+            C := UnderlyingCategory( UC );
+            
+            m1 := pair_of_lists1[2];
+            m2 := pair_of_lists2[2];
+            
+            return ForAll( [ 1 .. Length( m1 ) ], i -> IsCongruentForMorphisms( C, m1[i], m2[i] ) );
+            
+        end );
         
-        ## SkeletalFinSets code:
-        if not pair_of_lists1[1] = pair_of_lists2[1] then
-            return false;
-        fi;
-        
-        ## FiniteStrictCoproductCompletion code:
-        C := UnderlyingCategory( UC );
-        
-        m1 := pair_of_lists1[2];
-        m2 := pair_of_lists2[2];
-        
-        return ForAll( [ 1 .. Length( m1 ) ], i -> IsCongruentForMorphisms( C, m1[i], m2[i] ) );
-        
-    end );
+    fi;
     
     ##
     AddIdentityMorphism( UC,

--- a/FunctorCategories/PackageInfo.g
+++ b/FunctorCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FunctorCategories",
 Subtitle := "Categories of functors",
-Version := "2025.02-04",
+Version := "2025.02-05",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),

--- a/FunctorCategories/gap/PreSheaves.gi
+++ b/FunctorCategories/gap/PreSheaves.gi
@@ -712,6 +712,16 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
     skip := [ "MultiplyWithElementOfCommutativeRingForMorphisms",
              ];
     
+    if HasIsThinCategory( B ) and IsThinCategory( B ) and
+       IsIntervalCategory( D ) then
+        
+        Append( skip,
+                [ "IsMonomorphism",
+                  "IsEpimorphism",
+                  "IsCongruentForMorphisms" ] );
+        
+    fi;
+    
     list_of_operations_to_install := Difference( list_of_operations_to_install, skip );
     
     if HasCommutativeRingOfLinearCategory( D ) then
@@ -1196,19 +1206,23 @@ InstallMethodWithCache( PreSheavesOfFpEnrichedCategory,
             
         end );
         
-        AddIsCongruentForMorphisms( PSh,
-          function ( PSh, eta, epsilon )
-            local B, D, objects;
+        if not ( HasIsThinCategory( B ) and IsThinCategory( B ) and IsIntervalCategory( D ) ) then
             
-            B := Source( PSh );
-            D := Target( PSh );
+            AddIsCongruentForMorphisms( PSh,
+              function ( PSh, eta, epsilon )
+                local B, D, objects;
+                
+                B := Source( PSh );
+                D := Target( PSh );
+                
+                objects := SetOfObjects( B );
+                
+                return ForAll( objects, o -> IsCongruentForMorphisms( D, eta( o ), epsilon( o ) ) );
+                
+            end );
             
-            objects := SetOfObjects( B );
-            
-            return ForAll( objects, o -> IsCongruentForMorphisms( D, eta( o ), epsilon( o ) ) );
-            
-        end );
-          
+        fi;
+        
     fi;
     
     if HasRangeCategoryOfHomomorphismStructure( D ) and


### PR DESCRIPTION
* IsCongruentForMorphisms
* IsMonomorphism
* IsEpimorphism

since there are very cheap derivations installing them