### PR TITLE
Locales: Split two single-line conditionals into multi-line for Julia

### DIFF
--- a/Locales/PackageInfo.g
+++ b/Locales/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Locales",
 Subtitle := "Locales, frames, coframes, meet semi-lattices of locally closed subsets, and Boolean algebras of constructible sets",
-Version := "2026.03-03",
+Version := "2026.03-04",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/Locales/gap/ConstructibleObjects.gi
+++ b/Locales/gap/ConstructibleObjects.gi
@@ -350,13 +350,17 @@ InstallMethod( DisplayString,
     fi;
     
     s := DisplayString( A[1] );
-    if Length( s ) > 0 and s[Length( s )] = '\n' then s := s{[1 .. Length( s ) - 1]}; fi;
+    if Length( s ) > 0 and s[Length( s )] = '\n' then
+        s := s{[1 .. Length( s ) - 1]};
+    fi;
     display := Concatenation( "( ", s, " )" );
     
     for i in [ 2 .. n ] do
         Append( display, "\n\n∪\n\n" );
         s := DisplayString( A[i] );
-        if Length( s ) > 0 and s[Length( s )] = '\n' then s := s{[1 .. Length( s ) - 1]}; fi;
+        if Length( s ) > 0 and s[Length( s )] = '\n' then
+            s := s{[1 .. Length( s ) - 1]};
+        fi;
         Append( display, Concatenation( "( ", s, " )" ) );
     od;
     


### PR DESCRIPTION
The current transpilation script to Julia requires a line to end with `then` if it starts with `if`.

Bump Locales to V2026.03-04