### PR TITLE
release-gap-package: retry tag push up to 3 times to handle GitHub transient errors

### DIFF
--- a/dev/release-gap-package
+++ b/dev/release-gap-package
@@ -608,7 +608,18 @@ notice "Pushing your tag to GitHub"
 if [ "x$FORCE" = xyes ] ; then
     git push --force "$REMOTE" "$TAG"
 else
-    git push "$REMOTE" "$TAG"
+    tag_pushed=no
+    for attempt in 1 2 3; do
+        if git push "$REMOTE" "$TAG"; then
+            tag_pushed=yes
+            break
+        fi
+        if [ "$attempt" -lt 3 ]; then
+            notice "Tag push failed (attempt $attempt/3), retrying in 30s..."
+            sleep 30
+        fi
+    done
+    [ "$tag_pushed" = yes ] || exit 1
 fi
 
 


### PR DESCRIPTION
GitHub occasionally rejects tag pushes with "remote: fatal error in commit_refs". Hence, we retry the push up to 3 times with a 30-second delay between attempts before failing.