### PR TITLE
FiniteCocompletions: Remove Algebroids from dependencies

### DIFF
--- a/FiniteCocompletions/PackageInfo.g
+++ b/FiniteCocompletions/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FiniteCocompletions",
 Subtitle := "Finite (co)product/(co)limit (co)completions",
-Version := "2026.06-01",
+Version := "2026.06-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
@@ -97,7 +97,8 @@ Dependencies := rec(
                    [ "QuotientCategories", ">= 2026.04-01" ],
                    [ "Locales", ">= 2025.12-04" ],
                    [ "FpCategories", ">= 2025.12-05" ],
-                   [ "Algebroids", ">= 2026.04-01" ],
+                   [ "AdditiveClosuresForCAP", ">= 2026.04-01" ],
+                   [ "FreydCategoriesForCAP", ">= 2026.04-01" ],
                    [ "PresheafCategories", ">= 2026.05-01" ],
                    ],
   SuggestedOtherPackages := [ ],

--- a/FiniteCocompletions/examples/PrecompileFiniteStrictCoproductCompletionOfCategoryFromDataTables.g
+++ b/FiniteCocompletions/examples/PrecompileFiniteStrictCoproductCompletionOfCategoryFromDataTables.g
@@ -21,13 +21,13 @@ ReadPackageOnce( "Algebroids", "gap/CompilerLogic.gi" );
 ReadPackageOnce( "FunctorCategories", "gap/CompilerLogic.gi" );
 #! true
 
-free_category_of_quiver := { quiver, sFinSets } -> CategoryFromDataTables( FreeCategory( quiver : range_of_HomStructure := sFinSets, FinalizeCategory := true ) );;
+free_category_of_quiver := { quiver, sFinSets } -> CategoryFromDataTables( PathCategory( quiver : range_of_HomStructure := sFinSets, FinalizeCategory := true ) );;
 
 category_constructor :=
   function( quiver )
-    local sFinSets; sFinSets := SkeletalCategoryOfFiniteSets( : FinalizeCategory := true, overhead := true ); return FiniteStrictCoproductCompletion( CategoryFromDataTables( FreeCategory( quiver : range_of_HomStructure := sFinSets, FinalizeCategory := true ) : FinalizeCategory := true ) ); end;;
+    local sFinSets; sFinSets := SkeletalCategoryOfFiniteSets( : FinalizeCategory := true, overhead := true ); return FiniteStrictCoproductCompletion( CategoryFromDataTables( PathCategory( quiver : range_of_HomStructure := sFinSets, FinalizeCategory := true ) : FinalizeCategory := true ) ); end;;
 
-given_arguments := [ RightQuiver( "q(2)[m:1->2]" ) ];;
+given_arguments := [ FinQuiver( "q(2)[m:1->2]" ) ];;
 compiled_category_name := "FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled";;
 package_name := "FiniteCocompletions";;
 
@@ -47,10 +47,10 @@ CapJitPrecompileCategoryAndCompareResult(
 );;
 
 FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled( given_arguments[1] );
-#! FiniteStrictCoproductCompletion( FreeCategory( RightQuiver( "q(2)[m:1->2]" ) ) )
+#! FiniteStrictCoproductCompletion( PathCategory( FinQuiver( "q(1,2)[m:1→2]" ) ) )
 
 cat := FiniteStrictCoproductCompletion( free_category_of_quiver( given_arguments[1], SkeletalFinSets ) );
-#! FiniteStrictCoproductCompletion( FreeCategory( RightQuiver( "q(2)[m:1->2]" ) ) )
+#! FiniteStrictCoproductCompletion( PathCategory( FinQuiver( "q(1,2)[m:1→2]" ) ) )
 
 cat!.precompiled_functions_added;
 #! true

--- a/FiniteCocompletions/examples/precompileLeftCartesianDistributivityFactoring_CategoryFromDataTables.g
+++ b/FiniteCocompletions/examples/precompileLeftCartesianDistributivityFactoring_CategoryFromDataTables.g
@@ -9,6 +9,9 @@
 LoadPackage( "FiniteCocompletions", false );
 #! true
 
+LoadPackage( "Algebroids", false );
+#! true
+
 LoadPackage( "CompilerForCAP", ">= 2025.11-01", false );
 #! true
 

--- a/FiniteCocompletions/gap/FiniteStrictCoproductCompletion.gi
+++ b/FiniteCocompletions/gap/FiniteStrictCoproductCompletion.gi
@@ -1446,11 +1446,7 @@ InstallMethod( FiniteStrictCoproductCompletion,
     if CAP_NAMED_ARGUMENTS.no_precompiled_code <> true and
        HasRangeCategoryOfHomomorphismStructure( C ) then
         
-        if IsFpCategory( C ) and IsSkeletalCategoryOfFiniteSets( H ) then
-            
-            #ADD_FUNCTIONS_FOR_FiniteStrictCoproductCompletionOfFpCategoryPrecompiled( UC );
-            
-        elif IsCategoryFromDataTables( C ) and IsSkeletalCategoryOfFiniteSets( H ) then
+        if IsCategoryFromDataTables( C ) and IsSkeletalCategoryOfFiniteSets( H ) then
             
             ADD_FUNCTIONS_FOR_FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled( UC );
             

--- a/FiniteCocompletions/gap/precompiled_categories/FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled.gi
+++ b/FiniteCocompletions/gap/precompiled_categories/FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled.gi
@@ -632,7 +632,7 @@ BindGlobal( "FiniteStrictCoproductCompletionOfCategoryFromDataTablesPrecompiled"
     local sFinSets;
     sFinSets := SkeletalCategoryOfFiniteSets(  : FinalizeCategory := true,
         overhead := true );
-    return FiniteStrictCoproductCompletion( CategoryFromDataTables( FreeCategory( quiver : range_of_HomStructure := sFinSets,
+    return FiniteStrictCoproductCompletion( CategoryFromDataTables( PathCategory( quiver : range_of_HomStructure := sFinSets,
             FinalizeCategory := true ) : FinalizeCategory := true ) );
 end;
         


### PR DESCRIPTION
- Replace FreeCategory with PathCategory in precompiling examples.
- Simplify precompiled method selection; remove the empty FpCategory if-branch.
- Adjust dependencies: replace Algebroids with AdditiveClosuresForCAP and FreydCategoriesForCAP.

Bump FiniteCocompletions to v2026.06-02