### PR TITLE
PresheafCategories: guard overhead option with Julia block-comment trick

### DIFF
--- a/PresheafCategories/PackageInfo.g
+++ b/PresheafCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "PresheafCategories",
 Subtitle := "Categories of (co)presheaves",
-Version := "2026.07-01",
+Version := "2026.07-02",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/PresheafCategories/gap/PreSheaves.gi
+++ b/PresheafCategories/gap/PreSheaves.gi
@@ -788,7 +788,11 @@ InstallMethodWithCache( PreSheaves,
         
     fi;
     
-    PSh := CategoryConstructor( category_constructor_options : overhead := CAP_NAMED_ARGUMENTS.overhead );
+    PSh := CategoryConstructor( category_constructor_options
+    #= comment for Julia
+    : overhead := CAP_NAMED_ARGUMENTS.overhead
+    # =#
+    );
     
     if HasIsFiniteCategory( B ) and IsFiniteCategory( B ) and
        HasIsFiniteCategory( D ) and IsFiniteCategory( D ) then
@@ -965,8 +969,11 @@ InstallMethodWithCache( PreSheaves,
               object_datum := object_datum,
               morphism_constructor := morphism_constructor,
               morphism_datum := morphism_datum,
-              range_category_of_homomorphism_structure := H,
-              ) : overhead := CAP_NAMED_ARGUMENTS.overhead );
+              range_category_of_homomorphism_structure := H )
+              #= comment for Julia
+              : overhead := CAP_NAMED_ARGUMENTS.overhead
+              # =#
+              );
     
     ##
     SetSource( PSh_I_I, I );


### PR DESCRIPTION
Wrap the `: overhead := ...` option in the existing `#= comment for Julia ... # =#` pattern so that GAP still forwards the option while the Julia autogenerated code omits it. Ideally, we should make sure to to pass an option to category constructors only if they declare it as a named argument (i.e., not totally rely on the convenience of GAP).

Bump version to v2026.07-02