### PR TITLE
PresheafCategories: guard overhead option with Julia block-comment trick

### DIFF
--- a/PresheafCategories/PackageInfo.g
+++ b/PresheafCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "PresheafCategories",
 Subtitle := "Categories of (co)presheaves",
-Version := "2026.07-02",
+Version := "2026.07-03",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",

--- a/PresheafCategories/gap/PreSheavesWithBounds.gi
+++ b/PresheafCategories/gap/PreSheavesWithBounds.gi
@@ -266,7 +266,11 @@ InstallMethod( PreSheavesWithBounds,
         category_constructor_options.commutative_semiring_of_linear_category := CommutativeSemiringOfLinearCategory( PSh );
     fi;
     
-    xPSh := CategoryConstructor( category_constructor_options : overhead := CAP_NAMED_ARGUMENTS.overhead );
+    xPSh := CategoryConstructor( category_constructor_options
+                #= comment for Julia
+                : overhead := CAP_NAMED_ARGUMENTS.overhead
+                # =#
+                );
     
     SetSource( xPSh, C );
     SetTarget( xPSh, D );


### PR DESCRIPTION
Bump version of PresheafCategories to v2026.07-03