### PR TITLE
FpLinearCategories: Refactor LaTeXOutput for AlgebroidFromDataTables

### DIFF
--- a/FpLinearCategories/PackageInfo.g
+++ b/FpLinearCategories/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FpLinearCategories",
 Subtitle := "Finitely presented linear categories by generating quivers and relations",
-Version := "2026.07-05",
+Version := "2026.07-06",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -84,7 +84,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.13.0",
-  NeededOtherPackages := [ [ "CAP", ">= 2026.04-02" ],
+  NeededOtherPackages := [ [ "CAP", ">= 2026.07-03" ],
                            [ "FpCategories", ">= 2025.07-01" ],
                            [ "QuotientCategories", ">= 2026.04-01" ],
                            [ "LinearClosuresForCAP", ">= 2026.06-01" ],

--- a/FpLinearCategories/gap/AlgebroidFromDataTables.gi
+++ b/FpLinearCategories/gap/AlgebroidFromDataTables.gi
@@ -1072,9 +1072,9 @@ InstallMethod( LaTeXStringsOfBasesElements,
                                   ListN( labels,
                                     function ( l )
                                       if l[2] = 1 then
-                                        return Concatenation( "{", l[1], "}" );
+                                        return Concatenation( LATEX_LBRACE, l[1], LATEX_RBRACE );
                                       else
-                                        return Concatenation( "{", l[1], "}^{", String( l[2] ), "}" );
+                                        return Concatenation( LATEX_LBRACE, l[1], LATEX_RBRACE, "^", LATEX_LBRACE, String( l[2] ), LATEX_RBRACE );
                                       fi;
                                     end ), "" );
                         
@@ -1531,50 +1531,53 @@ InstallMethod( DisplayString,
 ##
 InstallMethod( LaTeXOutput,
           [ IsMorphismInFpAlgebroidFromDataTables ],
-  
-  function ( alpha )
-    local A, q, i, j, coeffs, support, string;
-    
-    A := CapCategory( alpha );
-    q := UnderlyingQuiver( A );
-    
-    i := ObjectIndex( Source( alpha ) );
-    j := ObjectIndex( Target( alpha ) );
-    
-    coeffs := CoefficientsList( alpha );
-    support := IndicesOfSupportMorphisms( alpha );
-    
-    if IsEmpty( support ) then
-        string := "0";
-    else
-        coeffs := List( coeffs{support},
-                    function ( c )
-                      
-                      if c in [ 1, -1 ] then
-                          return ReplacedString( LaTeXOutput( c ), "1", "" );
-                      else
-                          return Concatenation( LaTeXOutput( c ), "\\cdot " );
-                      fi;
-                      
-                    end );
+  FunctionWithNamedArguments(
+    [ [ "OnlyDatum", false ] ],
+    function ( CAP_NAMED_ARGUMENTS, alpha )
+      local A, q, i, j, coeffs, support, string;
+      
+      A := CapCategory( alpha );
+      q := UnderlyingQuiver( A );
+      
+      i := ObjectIndex( Source( alpha ) );
+      j := ObjectIndex( Target( alpha ) );
+      
+      coeffs := CoefficientsList( alpha );
+      support := IndicesOfSupportMorphisms( alpha );
+      
+      if IsEmpty( support ) then
+          string := "0";
+      else
+          coeffs := List( coeffs{support},
+                      function ( c )
+                        
+                        if c in [ 1, -1 ] then
+                            return ReplacedString( LaTeXOutput( c ), "1", "" );
+                        else
+                            return Concatenation( LaTeXOutput( c ), "\\cdot " );
+                        fi;
+                        
+                      end );
+          
+          string := LaTeXStringsOfBasesElements( A )[i][j]{support};
+          
+          string := ReplacedString( JoinStringsWithSeparator( ListN( coeffs, string, { c, l } -> Concatenation( c, l ) ), " + " ), "+ -", "- " );
+      fi;
+      
+      if CAP_NAMED_ARGUMENTS.OnlyDatum = true then
         
-        string := LaTeXStringsOfBasesElements( A )[i][j]{support};
+        return string;
         
-        string := ReplacedString( JoinStringsWithSeparator( ListN( coeffs, string, { c, l } -> Concatenation( c, l ) ), " + " ), "+ -", "- " );
-    fi;
-    
-    if ValueOption( "OnlyDatum" ) = true then
+      else
+        
+        return Concatenation(
+                  LATEX_LBRACE, LaTeXOutput( Source( alpha ) ), LATEX_RBRACE, "-\\left(",
+                  LATEX_LBRACE, string, LATEX_RBRACE, "\\right)\\rightarrow",
+                  LATEX_LBRACE, LaTeXOutput( Target( alpha ) ), LATEX_RBRACE );
       
-      return string;
+      fi;
       
-    else
-      
-      return Concatenation(
-                "{", LaTeXOutput( Source( alpha ) ), "}-\\left(",
-                "{", string, "}\\right)\\rightarrow",
-                "{", LaTeXOutput( Target( alpha ) ), "}" );
-    
-    fi;
-    
-end );
+    end
+  )
+);
 


### PR DESCRIPTION
- Use LATEX_LBRACE/LATEX_RBRACE for safer LaTeX string construction.
- Convert LaTeXOutput to FunctionWithNamedArguments with OnlyDatum (default false); replace ValueOption.

Bump FpLinearCategories to v2026.07-06 (require CAP to v2026.07-03)