### PR TITLE
Preparations for the `PermutationCategory`

### DIFF
--- a/SubcategoriesForCAP/PackageInfo.g
+++ b/SubcategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "SubcategoriesForCAP",
 Subtitle := "Subcategory and other related constructors for CAP categories",
-Version := "2026.07-01",
+Version := "2026.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -100,6 +100,22 @@ end );
 #
 ####################################
 
+#! @Description
+#!  Constructs a subcategory of C with name 'name'.
+#!  It supports the following options:
+#!  * 'is_full'
+#!  * 'is_additive'
+#!  * 'additional_operations_to_install': a list of strings with names of CAP operations
+#!     supported by the ambient category to additionally install in the subcategory.
+#!  * 'only_primitively_installed_operations_of_ambient_category': either 'true' or 'false'.
+#!     Decides, whether to consider only primitive operations or all installed operations of the ambient category,
+#!     when installing additional operations via "additional_operations_to_install" in the subcategory.
+#!  * 'properties'
+#!  * 'supports_empty_limits'
+#!  * 'FinalizeCategory'
+#!  * 'category_filter'
+#!  * 'category_object_filter'
+#!  * 'category_morphism_filter'
 #! @Arguments C, name
 DeclareOperation( "Subcategory",
                   [ IsCapCategory, IsString ] );

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -73,6 +73,13 @@ DeclareAttribute( "SetOfKnownObjects",
 DeclareAttribute( "AmbientCategory",
         IsCapSubcategory );
 
+CapJitAddTypeSignature( "AmbientCategory", [ IsCapSubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
 ####################################
 #
 #! @Section Constructors

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -22,7 +22,6 @@ DeclareCategory( "IsCapSubcategory",
 DeclareCategory( "IsCapSubcategoryGeneratedByFiniteNumberOfMorphisms",
         IsCapSubcategory );
 
-
 #! @Description
 #!  The &GAP; category of cells in a subcategory.
 DeclareCategory( "IsCellInASubcategory",
@@ -84,11 +83,21 @@ DeclareAttribute( "AmbientCategory",
 DeclareOperation( "Subcategory",
                   [ IsCapCategory, IsString ] );
 
-#! @Arguments D, c
+#! @Arguments D, object
+DeclareOperation( "AsSubcategoryObject",
+                  [ IsCapSubcategory, IsCapCategoryObject ] );
+
+
+#! @Arguments source, mor, range
+#! @Arguments D, morphism
+DeclareOperation( "AsSubcategoryMorphism",
+                  [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
+
+#! @Arguments D, cell
 DeclareOperation( "AsSubcategoryCell",
                   [ IsCapSubcategory, IsCapCategoryCell ] );
 
-#! @Arguments source, mor, range
+#! @Arguments source, morphism, target
 DeclareOperation( "AsSubcategoryCell",
                   [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
 

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -59,6 +59,20 @@ DeclareGlobalVariable( "CAP_INTERNAL_METHOD_NAME_LIST_FOR_SUBCATEGORY" );
 DeclareAttribute( "UnderlyingCell",
         IsCellInASubcategory );
 
+CapJitAddTypeSignature( "UnderlyingCell", [ IsObjectInASubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
+CapJitAddTypeSignature( "UnderlyingCell", [ IsMorphismInASubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
 #! @Description
 #!  The set of known objects of the subcategory <A>A</A>.
 #! @Arguments A

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -87,11 +87,27 @@ DeclareOperation( "Subcategory",
 DeclareOperation( "AsSubcategoryObject",
                   [ IsCapSubcategory, IsCapCategoryObject ] );
 
+CapJitAddTypeSignature( "AsSubcategoryObject", [ IsCapSubcategory, IsCapCategoryObject ],
+  function ( input_types )
+    
+    Assert( 0, AmbientCategory( input_types[1].category ) = input_types[2].category );
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
 
-#! @Arguments source, mor, range
 #! @Arguments D, morphism
 DeclareOperation( "AsSubcategoryMorphism",
                   [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
+
+CapJitAddTypeSignature( "AsSubcategoryMorphism", [ IsCapSubcategory, IsCapCategoryMorphism ],
+  function ( input_types )
+    
+    Assert( 0, AmbientCategory( input_types[1].category ) = input_types[2].category );
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 #! @Arguments D, cell
 DeclareOperation( "AsSubcategoryCell",

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -139,7 +139,7 @@ DeclareOperation( "AsSubcategoryCell",
                   [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
 
 #= comment for Julia
-#! @Arguments c, D
+#! @Arguments cell, D
 DeclareOperation( "\/",
                 [ IsCapCategoryCell, IsCapSubcategory ] );
 # =#

--- a/SubcategoriesForCAP/gap/Subcategory.gi
+++ b/SubcategoriesForCAP/gap/Subcategory.gi
@@ -24,17 +24,14 @@ InstallValue( CAP_INTERNAL_METHOD_NAME_LIST_FOR_SUBCATEGORY,
    ] );
 
 ##
-InstallMethod( AsSubcategoryCell,
+InstallMethodForCompilerForCAP( AsSubcategoryObject,
         "for a CAP category and a CAP object",
         [ IsCapSubcategory, IsCapCategoryObject ],
         
   function( D, object )
     
-    if not IsIdenticalObj( CapCategory( object ), AmbientCategory( D ) ) then
-        
-        Error( "the given object should belong to the ambient category: ", Name( AmbientCategory( D ) ), "\n" );
-        
-    fi;
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( object ), AmbientCategory( D ) ) );
     
     return CreateCapCategoryObjectWithAttributes( D,
                                                   UnderlyingCell, object );
@@ -42,27 +39,40 @@ InstallMethod( AsSubcategoryCell,
 end );
 
 ##
+InstallMethodForCompilerForCAP( AsSubcategoryMorphism,
+        "for two CAP objects in a subcategory and a CAP morphism",
+        [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ],
+        
+  function( D, source, morphism, target )
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( morphism ), AmbientCategory( D ) ) );
+    
+    return CreateCapCategoryMorphismWithAttributes( D,
+                                                    source,
+                                                    target,
+                                                    UnderlyingCell, morphism );
+    
+end );
+
+##
+InstallMethod( AsSubcategoryCell,
+        "for a CAP category and a CAP object",
+        [ IsCapSubcategory, IsCapCategoryObject ],
+        
+  { D, object } -> AsSubcategoryObject( D, object )
+  
+);
+
+##
 InstallMethod( AsSubcategoryCell,
         "for two CAP objects in a subcategory and a CAP morphism",
         [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ],
         
-  function( source, morphism, range )
-    local D;
-    
-    D := CapCategory( source );
-    
-    if not IsIdenticalObj( CapCategory( morphism ), AmbientCategory( D ) ) then
-        
-        Error( "the given morphism should belong to the ambient category: ", Name( AmbientCategory( D ) ), "\n" );
-        
-    fi;
-    
-    return CreateCapCategoryMorphismWithAttributes( D,
-                                                    source,
-                                                    range,
-                                                    UnderlyingCell, morphism );
-    
-end );
+  { source, morphism, target } ->
+        AsSubcategoryMorphism( CapCategory( source ), source, morphism, target )
+  
+);
 
 ##
 InstallMethod( AsSubcategoryCell,
@@ -71,11 +81,10 @@ InstallMethod( AsSubcategoryCell,
         
   function( D, morphism )
     
-    return AsSubcategoryCell(
-                   AsSubcategoryCell( D, Source( morphism ) ),
-                   morphism,
-                   AsSubcategoryCell( D, Target( morphism ) )
-                   );
+    return AsSubcategoryMorphism( D,
+                  AsSubcategoryObject( D, Source( morphism ) ),
+                  morphism,
+                  AsSubcategoryObject( D, Target( morphism ) ) );
     
 end );
 
@@ -110,9 +119,9 @@ InstallMethod( Subcategory,
          category_filter := CAP_NAMED_ARGUMENTS.category_filter,
          category_object_filter := CAP_NAMED_ARGUMENTS.category_object_filter,
          category_morphism_filter := CAP_NAMED_ARGUMENTS.category_morphism_filter,
-         object_constructor := { cat, obj } -> AsSubcategoryCell( cat, obj ),
+         object_constructor := { cat, obj } -> AsSubcategoryObject( cat, obj ),
          object_datum := { cat, obj } -> UnderlyingCell( obj ),
-         morphism_constructor := { cat, source, mor, range } -> AsSubcategoryCell( source, mor, range ),
+         morphism_constructor := { cat, source, mor, target } -> AsSubcategoryMorphism( cat, source, mor, target ),
          morphism_datum := { cat, mor } -> UnderlyingCell( mor ),
          underlying_category_getter_string := "AmbientCategory",
          underlying_category := C,

--- a/SubcategoriesForCAP/gap/Subcategory.gi
+++ b/SubcategoriesForCAP/gap/Subcategory.gi
@@ -103,6 +103,7 @@ InstallMethod( Subcategory,
     [ "is_full", false ],
     [ "is_additive", false ],
     [ "additional_operations_to_install", Immutable( [ ] ) ],
+    [ "only_primitively_installed_operations_of_ambient_category", true ],
     [ "properties", Immutable( [ ] ) ],
     [ "supports_empty_limits", false ],
     [ "FinalizeCategory", true ],
@@ -146,7 +147,11 @@ InstallMethod( Subcategory,
         Append( list_of_operations_to_install, CAP_INTERNAL_METHOD_NAME_LIST_FOR_ADDITIVE_FULL_SUBCATEGORY );
     fi;
     
-    list_of_operations_to_install := Intersection( list_of_operations_to_install, ListPrimitivelyInstalledOperationsOfCategory( C ) );
+    if CAP_NAMED_ARGUMENTS.only_primitively_installed_operations_of_ambient_category then
+        list_of_operations_to_install := Intersection( list_of_operations_to_install, ListPrimitivelyInstalledOperationsOfCategory( C ) );
+    else
+        list_of_operations_to_install := Intersection( list_of_operations_to_install, ListInstalledOperationsOfCategory( C ) );
+    fi;
     
     skip := [ "MultiplyWithElementOfCommutativeSemiringForMorphisms",
               ];


### PR DESCRIPTION
I had to introduce the boolean option `only_primitively_installed_operations_of_ambient_category` to the Subcategory constructor to make it possible to install certain non-primitive operations from the ambient category. By default, only primitively installed operations are considered:

https://github.com/homalg-project/CategoricalTowers/blob/5461d8d57f0b9d8a6ff3fede43e772189b43e7c2/SubcategoriesForCAP/gap/Subcategory.gi#L140

The main reason is, that `CoproductFunctorialWithGivenCoproducts` is not a primitively installed operation in SkeletalFinsets1, but I want to transfer it to the `PermutationCategory`, which I model as a subcategory.