### PR TITLE
D&I `PermutationCategory`

### DIFF
--- a/SubcategoriesForCAP/PackageInfo.g
+++ b/SubcategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "SubcategoriesForCAP",
 Subtitle := "Subcategory and other related constructors for CAP categories",
-Version := "2026.08-01",
+Version := "2026.08-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/SubcategoriesForCAP/PackageInfo.g
+++ b/SubcategoriesForCAP/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "SubcategoriesForCAP",
 Subtitle := "Subcategory and other related constructors for CAP categories",
-Version := "2026.07-01",
+Version := "2026.08-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/SubcategoriesForCAP/examples/PermutationCategory.g
+++ b/SubcategoriesForCAP/examples/PermutationCategory.g
@@ -1,0 +1,223 @@
+#! @Chapter Category of permutations
+#! @Section Examples and Tests
+
+#! @Example
+LoadPackage( "SubcategoriesForCAP", true );
+#! true
+
+cp := PermutationCategory( : no_precompiled_code := true );;
+
+Q := HomalgFieldOfRationals();;
+rows := CategoryOfRows( Q );;
+F := EmbeddingOfPermutationCategoryIntoCategoryOfRows( cp, rows );;
+
+o0 := ObjectConstructor( cp, 0 );;
+o1 := ObjectConstructor( cp, 1 );;
+o2 := ObjectConstructor( cp, 2 );;
+o4 := ObjectConstructor( cp, 4 );;
+o5 := ObjectConstructor( cp, 5 );;
+o10 := ObjectConstructor( cp, 10 );;
+
+mor_0 := MorphismConstructor( cp, o0, (), o0 );;
+mor_1 := MorphismConstructor( cp, o1, (), o1 );;
+mor_4_31 := MorphismConstructor( cp, o4, (3,1), o4 );;
+mor_4_23 := MorphismConstructor( cp, o4, (2,3), o4 );;
+mor_5_2415 := MorphismConstructor( cp, o5, (2,4,1,5), o5 );;
+mor_5_25 := MorphismConstructor( cp, o5, (2,5), o5 );;
+mor_5_0 := MorphismConstructor( cp, o5, (), o5 );;
+
+Cardinality( o0 );
+#! 0
+Cardinality( o4 );
+#! 4
+Cardinality( o5 );
+#! 5
+UnderlyingPermutation( mor_0 );
+#! ()
+UnderlyingPermutation( mor_4_31 );
+#! (1,3)
+UnderlyingPermutation( mor_5_2415 );
+#! (1,5,2,4)
+
+IsWellDefinedForObjects( o5 );
+#! true
+IsWellDefinedForMorphisms( mor_0 );
+#! true
+IsWellDefinedForMorphisms( mor_4_31 );
+#! true
+IsWellDefinedForMorphisms( mor_5_2415 );
+#! true
+
+id_o0 := IdentityMorphism( o0 );;
+id_o1 := IdentityMorphism( o1 );;
+id_o2 := IdentityMorphism( o2 );;
+id_o5 := IdentityMorphism( o5 );;
+
+IsWellDefinedForMorphisms( id_o0 );
+#! true
+IsWellDefinedForMorphisms( id_o5 );
+#! true
+
+IsEqualForObjects( o0, o0 );
+#! true
+IsEqualForObjects( o4, o4 );
+#! true
+IsEqualForObjects( o5, o5 );
+#! true
+IsEqualForObjects( o4, o5 );
+#! false
+IsEqualForObjects( o0, o5 );
+#! false
+
+IsEqualForMorphisms( mor_0, mor_0 );
+#! true
+IsEqualForMorphisms( mor_4_31, mor_4_31 );
+#! true
+IsEqualForMorphisms( mor_5_2415, mor_5_2415 );
+#! true
+IsEqualForMorphisms( mor_4_31, mor_4_23 );
+#! false
+IsEqualForMorphisms( mor_5_2415, mor_5_0 );
+#! false
+
+UnderlyingPermutation( PreCompose( mor_4_23, mor_4_31 ) );
+#! (1,3,2)
+UnderlyingPermutation( PreCompose( mor_4_31, mor_4_23 ) );
+#! (1,2,3)
+
+UnderlyingPermutation( InverseForMorphisms( mor_0 ) );
+#! ()
+UnderlyingPermutation( InverseForMorphisms( mor_4_31 ) );
+#! (1,3)
+UnderlyingPermutation( InverseForMorphisms( mor_5_2415 ) );
+#! (1,4,2,5)
+
+Cardinality( Coproduct( o2, o4 ) );
+#! 6
+Cardinality( Coproduct( o1, o4 ) );
+#! 5
+Cardinality( Coproduct( o2, o0 ) );
+#! 2
+Cardinality( Coproduct( o0, o0 ) );
+#! 0
+
+mor := CoproductFunctorial( [ mor_4_31, id_o2 ] );;
+m1 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_4_31 ), 4 ), Q );;
+m2 := HomalgMatrix( PermutationMat( UnderlyingPermutation( id_o2 ), 2 ), Q );;
+DiagMat( [ m1, m2 ] ) = HomalgMatrix( PermutationMat( UnderlyingPermutation( mor ), 6 ), Q );
+#! true
+
+mor := CoproductFunctorial( [ mor_4_23, mor_5_25 ] );;
+m1 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_4_23 ), 4 ), Q );;
+m2 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 ), Q );;
+DiagMat( [ m1, m2 ] ) = HomalgMatrix( PermutationMat( UnderlyingPermutation( mor ), 9 ) , Q );
+#! true
+
+mor := CoproductFunctorial( [ mor_1, mor_5_25 ] );;
+m1 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_1 ), 1 ), Q );;
+m2 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 ), Q );;
+DiagMat( [ m1, m2 ] ) = HomalgMatrix( PermutationMat( UnderlyingPermutation( mor ), 6 ) , Q );
+#! true
+
+mor := CoproductFunctorial( [ mor_5_25, mor_1 ] );;
+m1 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 ), Q );;
+m2 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_1 ), 1 ), Q );;
+DiagMat( [ m1, m2 ] ) = HomalgMatrix( PermutationMat( UnderlyingPermutation( mor ), 6), Q );
+#! true
+
+mor := CoproductFunctorial( [ mor_0, mor_0 ] );;
+m1 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_0 ), 0 ), Q );;
+m2 := HomalgMatrix( PermutationMat( UnderlyingPermutation( mor_0 ), 0 ), Q );;
+DiagMat( [ m1, m2 ] ) = HomalgMatrix( PermutationMat( UnderlyingPermutation( mor ), 0), Q );
+#! true
+
+Cardinality( TensorProductOnObjects( o2, o4 ) );
+#! 8
+Cardinality( TensorProductOnObjects( o1, o4 ) );
+#! 4
+Cardinality( TensorProductOnObjects( o2, o0 ) );
+#! 0
+
+mor := TensorProductOnMorphisms( id_o5, id_o2 );;
+m1 := PermutationMat( UnderlyingPermutation( id_o5 ), 5 );;
+m2 := PermutationMat( UnderlyingPermutation( id_o2 ), 2 );;
+KroneckerProduct( m1, m2 ) = PermutationMat( UnderlyingPermutation( mor ), 10 );
+#! true
+IsEqualForMorphisms( mor, IdentityMorphism( ObjectConstructor( cp, 10 ) ) );
+#! true
+
+mor := TensorProductOnMorphisms( mor_4_31, id_o2 );;
+m1 := PermutationMat( UnderlyingPermutation( mor_4_31 ), 4 );;
+m2 := PermutationMat( UnderlyingPermutation( id_o2 ), 2 );;
+KroneckerProduct( m1, m2 ) = PermutationMat( UnderlyingPermutation( mor ), 8 );
+#! true
+
+mor := TensorProductOnMorphisms( mor_4_23, mor_5_25 );;
+m1 := PermutationMat( UnderlyingPermutation( mor_4_23 ), 4 );;
+m2 := PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 );;
+KroneckerProduct( m1, m2 ) = PermutationMat( UnderlyingPermutation( mor ), 20 );
+#! true
+
+mor := TensorProductOnMorphisms( mor_1, mor_5_25 );;
+m1 := PermutationMat( UnderlyingPermutation( mor_1 ), 1 );;
+m2 := PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 );;
+KroneckerProduct( m1, m2 ) = PermutationMat( UnderlyingPermutation( mor ), 5 );
+#! true
+
+mor := TensorProductOnMorphisms( mor_5_25, mor_1 );;
+m1 := PermutationMat( UnderlyingPermutation( mor_5_25 ), 5 );;
+m2 := PermutationMat( UnderlyingPermutation( mor_1 ), 1 );;
+KroneckerProduct( m1, m2 ) = PermutationMat( UnderlyingPermutation( mor ), 5 );
+#! true
+
+Display( ApplyFunctor( F, o0 ) );
+#! A row module over Q of rank 0
+Display( ApplyFunctor( F, o1 ) );
+#! A row module over Q of rank 1
+Display( ApplyFunctor( F, o4 ) );
+#! A row module over Q of rank 4
+Display( ApplyFunctor( F, o5 ) );
+#! A row module over Q of rank 5
+Display( ApplyFunctor( F, mor ) );
+#! Source: 
+#! A row module over Q of rank 5
+#! 
+#! Matrix: 
+#! [ [  1,  0,  0,  0,  0 ],
+#!   [  0,  0,  0,  0,  1 ],
+#!   [  0,  0,  1,  0,  0 ],
+#!   [  0,  0,  0,  1,  0 ],
+#!   [  0,  1,  0,  0,  0 ] ]
+#! 
+#! Range: 
+#! A row module over Q of rank 5
+#! 
+#! A morphism in Rows( Q )
+
+o5o2 := TensorProductOnObjects( o5, o2 );;
+mor_5_25_times_id_o2 := TensorProductOnMorphismAndObjectWithGivenTensorProducts( cp, o5o2, mor_5_25, o2, o5o2 );;
+IsEqualForMorphisms( mor_5_25_times_id_o2, TensorProductOnMorphisms( mor_5_25, id_o2 ) );
+#! true
+Display( mor_5_25_times_id_o2 );
+#! 10 ⱶ(3,9)(4,10)→ 10
+Display( TensorProductOnMorphisms( mor_5_25, id_o2 ) );
+#! 10 ⱶ(3,9)(4,10)→ 10
+
+id_o5_times_id_o2 := TensorProductOnMorphismAndObjectWithGivenTensorProducts( cp, o10, id_o5, o2, o10 );;
+IsEqualForMorphisms( id_o5_times_id_o2, IdentityMorphism( o10 ) );
+#! true
+
+id_o2_times_mor_5_25 := TensorProductOnObjectAndMorphismWithGivenTensorProducts( cp, o5o2, o2, mor_5_25, o5o2 );;
+tp_mor := TensorProductOnMorphisms( id_o2, mor_5_25 );;
+IsEqualForMorphisms( id_o2_times_mor_5_25, tp_mor );
+#! true
+Display( id_o2_times_mor_5_25 );
+#! 10 ⱶ(2,5)(7,10)→ 10
+Display( id_o2_times_mor_5_25 );
+#! 10 ⱶ(2,5)(7,10)→ 10
+
+id_o5_times_id_o2 := TensorProductOnObjectAndMorphismWithGivenTensorProducts( cp, o10, o5, id_o2, o10 );;
+IsEqualForMorphisms( id_o5_times_id_o2, IdentityMorphism( o10 ) );
+#! true
+
+#! @EndExample

--- a/SubcategoriesForCAP/examples/precompile_PermutationCategory.g
+++ b/SubcategoriesForCAP/examples/precompile_PermutationCategory.g
@@ -1,0 +1,65 @@
+#! @Chapter Precompilation
+#! @Section Precompiling the category of permutations
+
+#! @Example
+
+#! #@if ValueOption( "no_precompiled_code" ) <> true
+
+LoadPackage( "SubcategoriesForCAP", false );
+#! true
+ReadPackageOnce( "FinSetsForCAP", "gap/CompilerLogic.gi" );
+#! true
+ReadPackageOnce( "FinSetsForCAP", "gap/CompilerLogicWithCountingStartingAt1.gi" );
+#! true
+ReadPackageOnce( "SubcategoriesForCAP", "gap/PermutationCategory_CompilerLogic.gi" );
+#! true
+
+category_constructor := { } -> PermutationCategory( : no_precompiled_code := true );;
+given_arguments := [ ];;
+compiled_category_name := "PermutationCategory_precompiled";;
+package_name := "SubcategoriesForCAP";;
+list_of_operations := SortedList( [
+    "ObjectConstructor",
+    "MorphismConstructor",
+    "ObjectDatum",
+    "MorphismDatum",
+    "IsEqualForObjects",
+    "IsEqualForMorphisms",
+    "IsCongruentForMorphisms",
+    "IsWellDefinedForObjects",
+    "IsWellDefinedForMorphisms",
+    "IdentityMorphism",
+    "PreCompose",
+    "InverseForMorphisms",
+    "Coproduct",
+    "CoproductFunctorialWithGivenCoproducts",
+    "TensorUnit",
+    "TensorProductOnObjects",
+    "TensorProductOnMorphismsWithGivenTensorProducts",
+    "TensorProductOnObjectAndMorphismWithGivenTensorProducts",
+    "TensorProductOnMorphismAndObjectWithGivenTensorProducts",
+] );;
+
+# CapJitSetDebugLevel( 1 );
+
+CapJitPrecompileCategoryAndCompareResult(
+        category_constructor,
+        given_arguments,
+        package_name,
+        compiled_category_name
+        : operations := list_of_operations,
+        number_of_objectified_objects_in_data_structure_of_object := 1,
+        number_of_objectified_morphisms_in_data_structure_of_object := 0,
+        number_of_objectified_objects_in_data_structure_of_morphism := 1,
+        number_of_objectified_morphisms_in_data_structure_of_morphism := 1
+);;
+
+cat := PermutationCategory( );
+#! PermutationCategory
+
+cat!.precompiled_functions_added;
+#! true
+
+#! #@fi
+
+#! @EndExample

--- a/SubcategoriesForCAP/gap/PermutationCategory.gd
+++ b/SubcategoriesForCAP/gap/PermutationCategory.gd
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SubcategoriesForCAP: Subcategory and other related constructors for CAP categories
+#
+# Declarations
+#
+
+#! @Chapter Category of permutations
+
+#! The skeletal category of permutations is the core of
+#! of the skeletal category of finite sets.
+#! Thus, its objects are the same as those of the
+#! skeletal category of finite sets and its morphisms
+#! are the isomorphisms of skeletal finite sets.
+#!
+#! More concretely, an object datum is an integer greater or equal to 0,
+#! and a morphism datum is a GAP permutation.
+
+####################################
+#
+#! @Section GAP categories
+#
+####################################
+
+DeclareCategory( "IsPermutationCategory", IsCapCategory );
+
+DeclareCategory( "IsObjectInPermutationCategory", IsCapCategoryObject );
+
+DeclareCategory( "IsMorphismInPermutationCategory", IsCapCategoryMorphism );
+
+####################################
+#
+#! @Section Constructors
+#
+####################################
+
+#! @Description
+#!  Construct a &CAP; category of permutations.
+DeclareOperation( "PermutationCategory", [ ] );
+
+####################################
+#
+#! @Section Attributes
+#
+####################################
+
+DeclareAttribute( "Cardinality", IsObjectInPermutationCategory );
+
+CapJitAddTypeSignature( "Cardinality", [ IsObjectInPermutationCategory ], IsBigInt );
+
+#! @Returns a &GAP; permutation
+DeclareAttribute( "UnderlyingPermutation", IsMorphismInPermutationCategory );
+
+CapJitAddTypeSignature( "UnderlyingPermutation", [ IsMorphismInPermutationCategory ], IsPerm );
+
+#######################################
+##
+#! @Section Functors
+##
+#######################################
+
+##
+DeclareOperation( "EmbeddingOfPermutationCategoryIntoCategoryOfRows",
+                  [ IsCapCategory, IsCapCategory ] );
+
+#######################################
+##
+## Type signatures for GAP permutations
+##
+#######################################
+
+CapJitAddTypeSignature( "*", [ IsPerm, IsPerm ], IsPerm );
+
+CapJitAddTypeSignature( "OnPoints", [ IsBigInt, IsPerm ], IsBigInt );
+
+# CapJitAddTypeSignature( "InverseImmutable", [ IsPerm ], IsPerm );
+
+CapJitAddTypeSignature( "ListPerm", [ IsPerm, IsBigInt ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfListOf( IsBigInt );
+    
+end );
+

--- a/SubcategoriesForCAP/gap/PermutationCategory.gi
+++ b/SubcategoriesForCAP/gap/PermutationCategory.gi
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SubcategoriesForCAP: Subcategory and other related constructors for CAP categories
+#
+# Implementations
+#
+
+ReadPackage( "SubcategoriesForCAP", "gap/precompiled_categories/PermutationCategory_precompiled.gi" );
+
+##
+InstallMethod( PermutationCategory,
+               [ ],
+               
+  FunctionWithNamedArguments(
+  [
+    [ "no_precompiled_code", false ],
+    [ "FinalizeCategory", true ],
+  ],
+  function( CAP_NAMED_ARGUMENTS )
+    local name, category_filter, category_object_filter, category_morphism_filter, object_datum_type, object_constructor, object_datum, morphism_datum_type, morphism_constructor, morphism_datum, sfinsets, sfinsets1, additional_operations_to_install, subcat, modeling_tower_object_constructor, modeling_tower_object_datum, modeling_tower_morphism_constructor, modeling_tower_morphism_datum, cat_of_perms;
+    
+    ##
+    name := "PermutationCategory";
+    
+    ##
+    category_filter := IsPermutationCategory;
+    category_object_filter := IsObjectInPermutationCategory;
+    category_morphism_filter := IsMorphismInPermutationCategory;
+    
+    ##
+    object_datum_type := IsBigInt;
+    
+    ##
+    object_constructor :=
+      function( cat_of_perms, cardinality )
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, 0 <= cardinality );
+        
+        return CreateCapCategoryObjectWithAttributes( cat_of_perms,
+                       Cardinality, cardinality );
+      
+    end;
+    
+    ##
+    object_datum := { cat_of_perms, object } -> Cardinality( object );
+    
+    ##
+    morphism_datum_type := IsPerm;
+    
+    ##
+    morphism_constructor :=
+      function( cat_of_perms, S, permutation, T )
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, Cardinality( S ) = Cardinality( T ) );
+        
+        #% CAP_JIT_DROP_NEXT_STATEMENT
+        Assert( 0, ForAll( ListPerm( permutation ), i ->
+            1 <= i and i <= Cardinality( S ) ) );
+        
+        return CreateCapCategoryMorphismWithAttributes( cat_of_perms,
+                    S,
+                    T,
+                    UnderlyingPermutation, permutation );
+        
+    end;
+    
+    ##
+    morphism_datum := { cat_of_perms, phi } -> UnderlyingPermutation( phi );
+    
+    ####################################
+    # Modeling
+    ####################################
+    
+    ## building the categorical tower:
+    
+    sfinsets := SkeletalCategoryOfFiniteSets( : FinalizeCategory := true );
+    sfinsets1 := SkeletalCategoryOfFiniteSetsWithCountingStartingAt1(
+                        sfinsets
+                        : cartesian_monoidal_structure := false,
+                          FinalizeCategory := true );
+    
+    additional_operations_to_install := [
+        "IsWellDefinedForObjects",
+        "Coproduct",
+        "CoproductFunctorial",
+        "CoproductFunctorialWithGivenCoproducts",
+    ];
+    
+    # We require only_primitively_installed_operations_of_ambient_category := false
+    # to automatically install the Coproduct methods from sfinsets1.
+    subcat := Subcategory( sfinsets1,
+                           "PermutationCategoryAsSubcategoryOfSkeletalFinSets"
+                           : additional_operations_to_install := additional_operations_to_install,
+                             only_primitively_installed_operations_of_ambient_category := false,
+                             FinalizeCategory := false );
+    
+    ##
+    AddIsWellDefinedForMorphisms( subcat,
+      function( subcat, morphism )
+        local sfinsets1;
+        
+        sfinsets1 := AmbientCategory( subcat );
+        
+        if not IsEqualForObjects( subcat, Source( morphism ), Target( morphism ) ) then
+            
+            return false;
+            
+        fi;
+        
+        return IsWellDefinedForMorphisms( sfinsets1, MorphismDatum( subcat, morphism ) );
+        
+    end );
+    
+    Finalize( subcat );
+    
+    ## From the raw object data to the object in the modeling category.
+    modeling_tower_object_constructor :=
+      function( cat_of_perms, cardinality )
+        local subcat, sfinsets1;
+        
+        subcat := ModelingCategory( cat_of_perms );
+        sfinsets1 := AmbientCategory( subcat );
+        
+        return ObjectConstructor( subcat, ObjectConstructor( sfinsets1, cardinality ) );
+        
+    end;
+    
+    ## From the object in the modeling category to the raw object data.
+    modeling_tower_object_datum :=
+      function( cat_of_perms, object )
+        local subcat, sfinsets1;
+        
+        subcat := ModelingCategory( cat_of_perms );
+        sfinsets1 := AmbientCategory( subcat );
+        
+        return Cardinality( ObjectDatum( subcat, object ) );
+        
+    end;
+    
+    ## From the raw morphism data to the morphism in the modeling category.
+    modeling_tower_morphism_constructor :=
+      function( cat_of_perms, source, permutation, target )
+        local subcat, sfinsets1, n, listperm;
+        
+        subcat := ModelingCategory( cat_of_perms );
+        sfinsets1 := AmbientCategory( subcat );
+        
+        n := Cardinality( ObjectDatum( subcat, source ) );
+        
+        listperm := ListPerm( permutation, n );
+        
+        return MorphismConstructor( subcat,
+                    source,
+                    MorphismConstructor( sfinsets1,
+                        ObjectDatum( subcat, source ),
+                        listperm,
+                        ObjectDatum( subcat, target ) ),
+                    target );
+        
+    end;
+    
+    ## From the morphism in the modeling category to the raw morphism data.
+    modeling_tower_morphism_datum :=
+      function( cat_of_perms, morphism )
+        local subcat, sfinsets1, listperm, permutation;
+        
+        subcat := ModelingCategory( cat_of_perms );
+        sfinsets1 := AmbientCategory( subcat );
+        
+        listperm := MorphismDatum( sfinsets1, MorphismDatum( subcat, morphism ) );
+        
+        return PermList( listperm );
+        
+    end;
+    
+    cat_of_perms := ReinterpretationOfCategory( subcat,
+                    rec( name := name,
+                         category_filter := category_filter,
+                         category_object_filter := category_object_filter,
+                         category_morphism_filter := category_morphism_filter,
+                         object_constructor := object_constructor,
+                         object_datum := object_datum,
+                         object_datum_type := object_datum_type,
+                         morphism_constructor := morphism_constructor,
+                         morphism_datum := morphism_datum,
+                         morphism_datum_type := morphism_datum_type,
+                         modeling_tower_object_constructor := modeling_tower_object_constructor,
+                         modeling_tower_object_datum := modeling_tower_object_datum,
+                         modeling_tower_morphism_constructor := modeling_tower_morphism_constructor,
+                         modeling_tower_morphism_datum := modeling_tower_morphism_datum,
+                         only_primitive_operations := true, )
+                    : FinalizeCategory := false );
+    
+    # DeactivateCachingOfCategory( cat_of_perms );
+    
+    # CapCategorySwitchLogicOff( cat_of_perms );
+    
+    ##
+    AddPreCompose( cat_of_perms,
+      function( cat_of_perms, alpha, beta )
+        local alpha_perm, beta_perm;
+        
+        alpha_perm := UnderlyingPermutation( alpha );
+        beta_perm := UnderlyingPermutation( beta );
+        
+        return MorphismConstructor( cat_of_perms,
+                                    Source( alpha ),
+                                    alpha_perm * beta_perm,
+                                    Target( beta ) );
+        
+    end );
+    
+    ##
+    AddInverseForMorphisms( cat_of_perms,
+      function( cat_of_perms, alpha )
+        local object, inverse_permutation;
+        
+        object := Source( alpha );
+        
+        inverse_permutation := InverseImmutable( UnderlyingPermutation( alpha ) );
+        
+        return MorphismConstructor( cat_of_perms, object, inverse_permutation, object );
+        
+    end );
+    
+    ## Coproduct is automatically installed from sfinsets1
+    ##
+    # AddCoproduct( cat_of_perms,
+    #   function( cat_of_perms, objects )
+    #     local sum;
+    #
+    #     sum := Sum( List( objects, object -> Cardinality( object ) ) );
+    #
+    #     return ObjectConstructor( cat_of_perms, sum );
+    #
+    # end );
+    
+    ## CoproductFunctorialWithGivenCoproducts is automatically installed from sfinsets1
+    ##
+    # AddCoproductFunctorialWithGivenCoproducts( cat_of_perms,
+    #   function( cat_of_perms, source, source_diagram, morphisms, target_diagram, target )
+    #     local nr_morphisms, perm_lists, cardinalities, offsets, product_perm_list, product_perm;
+    #
+    #     nr_morphisms := Length( morphisms );
+    #
+    #     perm_lists := List( [ 1 .. nr_morphisms ], i ->
+    #         ListPerm( UnderlyingPermutation( morphisms[i] ), Cardinality( source_diagram[i] ) ) );
+    #
+    #     cardinalities := List( [ 1 .. nr_morphisms ], i -> Cardinality( source_diagram[i] ) );
+    #
+    #     offsets := List( [ 1 .. nr_morphisms ], i -> Sum( cardinalities{[ 1 .. i-1 ]} ) );
+    #
+    #     product_perm_list := Concatenation( List( [ 1 .. nr_morphisms ], i ->
+    #          List( perm_lists[i], j -> j + offsets[i] ) ) );
+    #
+    #     product_perm := PermList( product_perm_list );
+    #
+    #     return MorphismConstructor( cat_of_perms, source, product_perm, target );
+    #
+    # end );
+    
+    ##
+    AddTensorUnit( cat_of_perms,
+      function( cat_of_perms )
+        
+        return ObjectConstructor( cat_of_perms, 1 );
+        
+    end );
+    
+    ##
+    AddTensorProductOnObjects( cat_of_perms,
+      function( cat_of_perms, object_1, object_2 )
+        
+        return ObjectConstructor( cat_of_perms, Cardinality( object_1 ) * Cardinality( object_2 ) );
+        
+    end );
+    
+    AddTensorProductOnMorphismsWithGivenTensorProducts( cat_of_perms,
+      function( cat_of_perms, source, morphism_1, morphism_2, target )
+        local source_1, source_2, m, n, mn, perm1, perm2, kronecker_list, pairs, pairs_applied, kronecker_perm;
+        
+        source_1 := Source( morphism_1 );
+        source_2 := Source( morphism_2 );
+        
+        m := Cardinality( source_1 );
+        n := Cardinality( source_2 );
+        mn := Cardinality( source );
+        
+        perm1 := UnderlyingPermutation( morphism_1 );
+        perm2 := UnderlyingPermutation( morphism_2 );
+        
+        kronecker_list := List([ 1 .. mn ], k ->
+            ( OnPoints( QuoInt( k - 1, n ) + 1, perm1 ) - 1 ) * n +
+              OnPoints( RemInt( k - 1, n ) + 1, perm2 ) );
+        
+        kronecker_perm := PermList( kronecker_list );
+        
+        return MorphismConstructor( cat_of_perms, source, kronecker_perm, target );
+        
+    end );
+    
+    AddTensorProductOnMorphismAndObjectWithGivenTensorProducts( cat_of_perms,
+      function( cat_of_perms, source, morphism, object, target )
+        local permutation, source_morphism, cardinality, kronecker_permutation;
+        
+        source_morphism := Source( morphism );
+        
+        permutation := ListPerm( UnderlyingPermutation( morphism ), Cardinality( source_morphism ) );
+        cardinality := Cardinality( object );
+        
+        kronecker_permutation :=
+            Concatenation( List( permutation, p ->
+                List( [ 1 .. cardinality ], i -> (p - 1) * cardinality + i ) ) );
+        
+        return MorphismConstructor( cat_of_perms,
+                    source,
+                    PermList( kronecker_permutation ),
+                    source );
+        
+    end );
+    
+    
+    AddTensorProductOnObjectAndMorphismWithGivenTensorProducts( cat_of_perms,
+      function( cat_of_perms, source, object, morphism, target )
+        local source_morphism, cardinality_morphism, cardinality_object, permutation, kronecker_permutation;
+        
+        source_morphism := Source( morphism );
+        
+        cardinality_morphism := Cardinality( source_morphism );
+        cardinality_object := Cardinality( object );
+        
+        permutation := ListPerm( UnderlyingPermutation( morphism ), cardinality_morphism );
+        
+        kronecker_permutation := Concatenation( List( [ 0 .. cardinality_object - 1 ], i ->
+            List( permutation, p -> p + i * cardinality_morphism ) ) );
+        
+        return MorphismConstructor( cat_of_perms,
+                    source,
+                    PermList( kronecker_permutation ),
+                    source );
+        
+    end );
+    
+    if CAP_NAMED_ARGUMENTS.no_precompiled_code <> true then
+        
+        ADD_FUNCTIONS_FOR_PermutationCategory_precompiled( cat_of_perms );
+        
+    fi;
+    
+    if CAP_NAMED_ARGUMENTS.FinalizeCategory then
+        
+        Finalize( cat_of_perms );
+        
+    fi;
+    
+    return cat_of_perms;
+    
+end ) );
+
+####################################
+##
+## Functors
+##
+####################################
+
+##
+InstallMethod( EmbeddingOfPermutationCategoryIntoCategoryOfRows,
+               [ IsCapCategory, IsCapCategory ],
+               
+  function( cat_of_perms, rows )
+    local homalg_ring, functor;
+    
+    Assert( 0, IsCategoryOfRows( rows) );
+    
+    homalg_ring := UnderlyingRing( rows );
+    
+    functor := CapFunctor( Concatenation( "Embedding from ", Name( cat_of_perms ), " to ", Name( rows ) ), cat_of_perms, rows );
+    
+    AddObjectFunction( functor,
+      function( object )
+        
+        return ObjectConstructor( rows, Cardinality( object ) );
+        
+    end );
+    
+    AddMorphismFunction( functor,
+      function( source, morphism, target )
+        local nr, permutation, matrix;
+        
+        nr := RankOfObject( source );
+        
+        permutation :=  UnderlyingPermutation( morphism );
+        
+        matrix := HomalgMatrix( PermutationMat( permutation, nr ), homalg_ring );
+        
+        return AsCategoryOfRowsMorphism( rows, matrix );
+        
+    end );
+    
+    return functor;
+    
+end );
+
+####################################
+##
+## View & Display
+##
+####################################
+
+InstallMethod( DisplayString,
+               [ IsObjectInPermutationCategory ],
+               
+  object -> Cardinality( object )
+  
+);
+
+InstallMethod( DisplayString,
+               [ IsMorphismInPermutationCategory ],
+               
+  function( morphism )
+    local object, permutation;
+    
+    object := Cardinality( Source( morphism ) );
+    
+    permutation := UnderlyingPermutation( morphism );
+    
+    return Concatenation( String( object ),
+                          " ⱶ",
+                          String( permutation ),
+                          "→ ",
+                          String( object ) );
+    
+end );
+

--- a/SubcategoriesForCAP/gap/PermutationCategory_CompilerLogic.gi
+++ b/SubcategoriesForCAP/gap/PermutationCategory_CompilerLogic.gi
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SubcategoriesForCAP: Subcategory and other related constructors for CAP categories
+#
+# Implementations
+#
+
+##
+CapJitAddLogicTemplate(
+    rec(
+        variable_names := [ "m", "n", "alpha", "beta" ],
+        variable_filters := [ IsBigInt, IsBigInt, IsMorphismInPermutationCategory, IsMorphismInPermutationCategory ],
+        src_template :=
+            "PermList( List( [ 1 .. m ], i -> ListPerm( UnderlyingPermutation( beta ), n )[ ListPerm( UnderlyingPermutation( alpha ), m )[i] ] ) )",
+        dst_template := "UnderlyingPermutation( alpha ) * UnderlyingPermutation( beta )",
+    )
+);
+

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -100,6 +100,22 @@ end );
 #
 ####################################
 
+#! @Description
+#!  Constructs a subcategory of C with name 'name'.
+#!  It supports the following options:
+#!  * 'is_full'
+#!  * 'is_additive'
+#!  * 'additional_operations_to_install': a list of strings with names of CAP operations
+#!     supported by the ambient category to additionally install in the subcategory.
+#!  * 'only_primitively_installed_operations_of_ambient_category': either 'true' or 'false'.
+#!     Decides, whether to consider only primitive operations or all installed operations of the ambient category,
+#!     when installing additional operations via "additional_operations_to_install" in the subcategory.
+#!  * 'properties'
+#!  * 'supports_empty_limits'
+#!  * 'FinalizeCategory'
+#!  * 'category_filter'
+#!  * 'category_object_filter'
+#!  * 'category_morphism_filter'
 #! @Arguments C, name
 DeclareOperation( "Subcategory",
                   [ IsCapCategory, IsString ] );

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -73,6 +73,13 @@ DeclareAttribute( "SetOfKnownObjects",
 DeclareAttribute( "AmbientCategory",
         IsCapSubcategory );
 
+CapJitAddTypeSignature( "AmbientCategory", [ IsCapSubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
 ####################################
 #
 #! @Section Constructors

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -22,7 +22,6 @@ DeclareCategory( "IsCapSubcategory",
 DeclareCategory( "IsCapSubcategoryGeneratedByFiniteNumberOfMorphisms",
         IsCapSubcategory );
 
-
 #! @Description
 #!  The &GAP; category of cells in a subcategory.
 DeclareCategory( "IsCellInASubcategory",
@@ -84,11 +83,21 @@ DeclareAttribute( "AmbientCategory",
 DeclareOperation( "Subcategory",
                   [ IsCapCategory, IsString ] );
 
-#! @Arguments D, c
+#! @Arguments D, object
+DeclareOperation( "AsSubcategoryObject",
+                  [ IsCapSubcategory, IsCapCategoryObject ] );
+
+
+#! @Arguments source, mor, range
+#! @Arguments D, morphism
+DeclareOperation( "AsSubcategoryMorphism",
+                  [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
+
+#! @Arguments D, cell
 DeclareOperation( "AsSubcategoryCell",
                   [ IsCapSubcategory, IsCapCategoryCell ] );
 
-#! @Arguments source, mor, range
+#! @Arguments source, morphism, target
 DeclareOperation( "AsSubcategoryCell",
                   [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
 

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -59,6 +59,20 @@ DeclareGlobalVariable( "CAP_INTERNAL_METHOD_NAME_LIST_FOR_SUBCATEGORY" );
 DeclareAttribute( "UnderlyingCell",
         IsCellInASubcategory );
 
+CapJitAddTypeSignature( "UnderlyingCell", [ IsObjectInASubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfObjectOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
+CapJitAddTypeSignature( "UnderlyingCell", [ IsMorphismInASubcategory ],
+  function ( input_types )
+    
+    return CapJitDataTypeOfMorphismOfCategory( AmbientCategory( input_types[1].category ) );
+    
+end );
+
 #! @Description
 #!  The set of known objects of the subcategory <A>A</A>.
 #! @Arguments A

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -87,11 +87,27 @@ DeclareOperation( "Subcategory",
 DeclareOperation( "AsSubcategoryObject",
                   [ IsCapSubcategory, IsCapCategoryObject ] );
 
+CapJitAddTypeSignature( "AsSubcategoryObject", [ IsCapSubcategory, IsCapCategoryObject ],
+  function ( input_types )
+    
+    Assert( 0, AmbientCategory( input_types[1].category ) = input_types[2].category );
+    
+    return CapJitDataTypeOfObjectOfCategory( input_types[1].category );
+    
+end );
 
-#! @Arguments source, mor, range
 #! @Arguments D, morphism
 DeclareOperation( "AsSubcategoryMorphism",
                   [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
+
+CapJitAddTypeSignature( "AsSubcategoryMorphism", [ IsCapSubcategory, IsCapCategoryMorphism ],
+  function ( input_types )
+    
+    Assert( 0, AmbientCategory( input_types[1].category ) = input_types[2].category );
+    
+    return CapJitDataTypeOfMorphismOfCategory( input_types[1].category );
+    
+end );
 
 #! @Arguments D, cell
 DeclareOperation( "AsSubcategoryCell",

--- a/SubcategoriesForCAP/gap/Subcategory.gd
+++ b/SubcategoriesForCAP/gap/Subcategory.gd
@@ -139,7 +139,7 @@ DeclareOperation( "AsSubcategoryCell",
                   [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ] );
 
 #= comment for Julia
-#! @Arguments c, D
+#! @Arguments cell, D
 DeclareOperation( "\/",
                 [ IsCapCategoryCell, IsCapSubcategory ] );
 # =#

--- a/SubcategoriesForCAP/gap/Subcategory.gi
+++ b/SubcategoriesForCAP/gap/Subcategory.gi
@@ -24,17 +24,14 @@ InstallValue( CAP_INTERNAL_METHOD_NAME_LIST_FOR_SUBCATEGORY,
    ] );
 
 ##
-InstallMethod( AsSubcategoryCell,
+InstallMethodForCompilerForCAP( AsSubcategoryObject,
         "for a CAP category and a CAP object",
         [ IsCapSubcategory, IsCapCategoryObject ],
         
   function( D, object )
     
-    if not IsIdenticalObj( CapCategory( object ), AmbientCategory( D ) ) then
-        
-        Error( "the given object should belong to the ambient category: ", Name( AmbientCategory( D ) ), "\n" );
-        
-    fi;
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( object ), AmbientCategory( D ) ) );
     
     return CreateCapCategoryObjectWithAttributes( D,
                                                   UnderlyingCell, object );
@@ -42,27 +39,40 @@ InstallMethod( AsSubcategoryCell,
 end );
 
 ##
+InstallMethodForCompilerForCAP( AsSubcategoryMorphism,
+        "for two CAP objects in a subcategory and a CAP morphism",
+        [ IsCapSubcategory, IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ],
+        
+  function( D, source, morphism, target )
+    
+    #% CAP_JIT_DROP_NEXT_STATEMENT
+    Assert( 0, IsIdenticalObj( CapCategory( morphism ), AmbientCategory( D ) ) );
+    
+    return CreateCapCategoryMorphismWithAttributes( D,
+                                                    source,
+                                                    target,
+                                                    UnderlyingCell, morphism );
+    
+end );
+
+##
+InstallMethod( AsSubcategoryCell,
+        "for a CAP category and a CAP object",
+        [ IsCapSubcategory, IsCapCategoryObject ],
+        
+  { D, object } -> AsSubcategoryObject( D, object )
+  
+);
+
+##
 InstallMethod( AsSubcategoryCell,
         "for two CAP objects in a subcategory and a CAP morphism",
         [ IsObjectInASubcategory, IsCapCategoryMorphism, IsObjectInASubcategory ],
         
-  function( source, morphism, range )
-    local D;
-    
-    D := CapCategory( source );
-    
-    if not IsIdenticalObj( CapCategory( morphism ), AmbientCategory( D ) ) then
-        
-        Error( "the given morphism should belong to the ambient category: ", Name( AmbientCategory( D ) ), "\n" );
-        
-    fi;
-    
-    return CreateCapCategoryMorphismWithAttributes( D,
-                                                    source,
-                                                    range,
-                                                    UnderlyingCell, morphism );
-    
-end );
+  { source, morphism, target } ->
+        AsSubcategoryMorphism( CapCategory( source ), source, morphism, target )
+  
+);
 
 ##
 InstallMethod( AsSubcategoryCell,
@@ -71,11 +81,10 @@ InstallMethod( AsSubcategoryCell,
         
   function( D, morphism )
     
-    return AsSubcategoryCell(
-                   AsSubcategoryCell( D, Source( morphism ) ),
-                   morphism,
-                   AsSubcategoryCell( D, Target( morphism ) )
-                   );
+    return AsSubcategoryMorphism( D,
+                  AsSubcategoryObject( D, Source( morphism ) ),
+                  morphism,
+                  AsSubcategoryObject( D, Target( morphism ) ) );
     
 end );
 
@@ -110,9 +119,9 @@ InstallMethod( Subcategory,
          category_filter := CAP_NAMED_ARGUMENTS.category_filter,
          category_object_filter := CAP_NAMED_ARGUMENTS.category_object_filter,
          category_morphism_filter := CAP_NAMED_ARGUMENTS.category_morphism_filter,
-         object_constructor := { cat, obj } -> AsSubcategoryCell( cat, obj ),
+         object_constructor := { cat, obj } -> AsSubcategoryObject( cat, obj ),
          object_datum := { cat, obj } -> UnderlyingCell( obj ),
-         morphism_constructor := { cat, source, mor, range } -> AsSubcategoryCell( source, mor, range ),
+         morphism_constructor := { cat, source, mor, target } -> AsSubcategoryMorphism( cat, source, mor, target ),
          morphism_datum := { cat, mor } -> UnderlyingCell( mor ),
          underlying_category_getter_string := "AmbientCategory",
          underlying_category := C,

--- a/SubcategoriesForCAP/gap/Subcategory.gi
+++ b/SubcategoriesForCAP/gap/Subcategory.gi
@@ -103,6 +103,7 @@ InstallMethod( Subcategory,
     [ "is_full", false ],
     [ "is_additive", false ],
     [ "additional_operations_to_install", Immutable( [ ] ) ],
+    [ "only_primitively_installed_operations_of_ambient_category", true ],
     [ "properties", Immutable( [ ] ) ],
     [ "supports_empty_limits", false ],
     [ "FinalizeCategory", true ],
@@ -146,7 +147,11 @@ InstallMethod( Subcategory,
         Append( list_of_operations_to_install, CAP_INTERNAL_METHOD_NAME_LIST_FOR_ADDITIVE_FULL_SUBCATEGORY );
     fi;
     
-    list_of_operations_to_install := Intersection( list_of_operations_to_install, ListPrimitivelyInstalledOperationsOfCategory( C ) );
+    if CAP_NAMED_ARGUMENTS.only_primitively_installed_operations_of_ambient_category then
+        list_of_operations_to_install := Intersection( list_of_operations_to_install, ListPrimitivelyInstalledOperationsOfCategory( C ) );
+    else
+        list_of_operations_to_install := Intersection( list_of_operations_to_install, ListInstalledOperationsOfCategory( C ) );
+    fi;
     
     skip := [ "MultiplyWithElementOfCommutativeSemiringForMorphisms",
               ];

--- a/SubcategoriesForCAP/gap/precompiled_categories/PermutationCategory_precompiled.gi
+++ b/SubcategoriesForCAP/gap/precompiled_categories/PermutationCategory_precompiled.gi
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SubcategoriesForCAP: Subcategory and other related constructors for CAP categories
+#
+# Implementations
+#
+BindGlobal( "ADD_FUNCTIONS_FOR_PermutationCategory_precompiled", function ( cat )
+    
+    ##
+    AddCoproduct( cat,
+        
+########
+function ( cat_1, objects_1 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Cardinality, Sum( List( objects_1, Cardinality ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddCoproductFunctorialWithGivenCoproducts( cat,
+        
+########
+function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
+    local deduped_1_1;
+    deduped_1_1 := List( objectsp_1, Cardinality );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, UnderlyingPermutation, PermList( Concatenation( List( [ 1 .. Length( L_1 ) ], function ( i_2 )
+                  local hoisted_1_2, hoisted_2_2, deduped_3_2, deduped_4_2, deduped_5_2;
+                  deduped_5_2 := CAP_JIT_INCOMPLETE_LOGIC( L_1[i_2] );
+                  deduped_4_2 := Sum( deduped_1_1{[ 1 .. i_2 - 1 ]} );
+                  deduped_3_2 := Cardinality( Source( deduped_5_2 ) );
+                  hoisted_2_2 := List( [ deduped_4_2 .. deduped_4_2 + deduped_1_1[i_2] - 1 ], function ( i_3 )
+                          return 1 + i_3;
+                      end );
+                  hoisted_1_2 := CAP_JIT_INCOMPLETE_LOGIC( ListPerm( UnderlyingPermutation( deduped_5_2 ), deduped_3_2 ) );
+                  return List( [ 1 .. CAP_JIT_INCOMPLETE_LOGIC( deduped_3_2 ) ], function ( i_3 )
+                          return hoisted_2_2[hoisted_1_2[i_3]];
+                      end );
+              end ) ) ) );
+end
+########
+        
+    , 503 );
+    
+    ##
+    cat!.cached_precompiled_functions.CoproductFunctorialWithGivenCoproducts :=
+        
+########
+function ( cat_1, P_1, objects_1, L_1, objectsp_1, Pp_1 )
+    local hoisted_1_1, deduped_2_1, hoisted_3_1;
+    hoisted_3_1 := List( L_1, function ( x_2 )
+            return ListPerm( UnderlyingPermutation( x_2 ), Cardinality( Source( x_2 ) ) );
+        end );
+    deduped_2_1 := List( objectsp_1, Cardinality );
+    hoisted_1_1 := List( L_1, function ( x_2 )
+            return Cardinality( Source( x_2 ) );
+        end );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, P_1, Pp_1, UnderlyingPermutation, PermList( Concatenation( List( [ 1 .. Length( L_1 ) ], function ( i_2 )
+                  local hoisted_1_2, hoisted_2_2, deduped_3_2;
+                  deduped_3_2 := Sum( deduped_2_1{[ 1 .. i_2 - 1 ]} );
+                  hoisted_2_2 := List( [ deduped_3_2 .. deduped_3_2 + deduped_2_1[i_2] - 1 ], function ( i_3 )
+                          return 1 + i_3;
+                      end );
+                  hoisted_1_2 := hoisted_3_1[i_2];
+                  return List( [ 1 .. hoisted_1_1[i_2] ], function ( i_3 )
+                          return hoisted_2_2[hoisted_1_2[i_3]];
+                      end );
+              end ) ) ) );
+end
+########
+        
+    ;
+    
+    ##
+    AddIdentityMorphism( cat,
+        
+########
+function ( cat_1, a_1 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, a_1, a_1, UnderlyingPermutation, PermList( [ 1 .. Cardinality( a_1 ) ] ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddInverseForMorphisms( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_1_1;
+    deduped_1_1 := Source( alpha_1 );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, deduped_1_1, deduped_1_1, UnderlyingPermutation, InverseImmutable( UnderlyingPermutation( alpha_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsCongruentForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return ListPerm( UnderlyingPermutation( arg2_1 ), Cardinality( Source( arg2_1 ) ) ) = ListPerm( UnderlyingPermutation( arg3_1 ), Cardinality( Source( arg3_1 ) ) );
+end
+########
+        
+    , 101 );
+    
+    ##
+    AddIsEqualForMorphisms( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return ListPerm( UnderlyingPermutation( arg2_1 ), Cardinality( Source( arg2_1 ) ) ) = ListPerm( UnderlyingPermutation( arg3_1 ), Cardinality( Source( arg3_1 ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsEqualForObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return Cardinality( arg2_1 ) = Cardinality( arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsWellDefinedForMorphisms( cat,
+        
+########
+function ( cat_1, alpha_1 )
+    local deduped_2_1, deduped_3_1, deduped_4_1, deduped_5_1;
+    deduped_5_1 := Cardinality( Range( alpha_1 ) );
+    deduped_4_1 := Cardinality( Source( alpha_1 ) );
+    if not deduped_4_1 = deduped_5_1 then
+        return false;
+    else
+        deduped_3_1 := ListPerm( UnderlyingPermutation( alpha_1 ), deduped_4_1 );
+        deduped_2_1 := List( deduped_3_1, function ( i_2 )
+                return -1 + i_2;
+            end );
+        return ForAll( deduped_2_1, function ( a_2 )
+                    return IsBigInt( a_2 ) and a_2 >= 0;
+                end ) and deduped_4_1 = Length( deduped_3_1 ) and ForAll( deduped_2_1, function ( a_2 )
+                  return a_2 < deduped_5_1;
+              end );
+    fi;
+    return;
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddIsWellDefinedForObjects( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    local deduped_1_1;
+    deduped_1_1 := Cardinality( arg2_1 );
+    return IsBigInt( deduped_1_1 ) and deduped_1_1 >= 0;
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismConstructor( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1, arg4_1 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, arg2_1, arg4_1, UnderlyingPermutation, arg3_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddMorphismDatum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return UnderlyingPermutation( arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddObjectConstructor( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Cardinality, arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddObjectDatum( cat,
+        
+########
+function ( cat_1, arg2_1 )
+    return Cardinality( arg2_1 );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddPreCompose( cat,
+        
+########
+function ( cat_1, alpha_1, beta_1 )
+    return CreateCapCategoryMorphismWithAttributes( cat_1, Source( alpha_1 ), Target( beta_1 ), UnderlyingPermutation, UnderlyingPermutation( alpha_1 ) * UnderlyingPermutation( beta_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorProductOnMorphismAndObjectWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, b_1, r_1 )
+    local hoisted_2_1, deduped_3_1;
+    deduped_3_1 := Cardinality( b_1 );
+    hoisted_2_1 := [ 1 .. deduped_3_1 ];
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, s_1, UnderlyingPermutation, PermList( Concatenation( List( ListPerm( UnderlyingPermutation( alpha_1 ), Cardinality( Source( alpha_1 ) ) ), function ( p_2 )
+                  local hoisted_1_2;
+                  hoisted_1_2 := (p_2 - 1) * deduped_3_1;
+                  return List( hoisted_2_1, function ( i_3 )
+                          return hoisted_1_2 + i_3;
+                      end );
+              end ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorProductOnMorphismsWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, alpha_1, beta_1, r_1 )
+    local deduped_3_1, hoisted_4_1, hoisted_5_1;
+    hoisted_5_1 := UnderlyingPermutation( beta_1 );
+    hoisted_4_1 := UnderlyingPermutation( alpha_1 );
+    deduped_3_1 := Cardinality( Source( beta_1 ) );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, r_1, UnderlyingPermutation, PermList( List( [ 1 .. Cardinality( s_1 ) ], function ( k_2 )
+                local deduped_1_2;
+                deduped_1_2 := k_2 - 1;
+                return (OnPoints( QUO_INT( deduped_1_2, deduped_3_1 ) + 1, hoisted_4_1 ) - 1) * deduped_3_1 + OnPoints( REM_INT( deduped_1_2, deduped_3_1 ) + 1, hoisted_5_1 );
+            end ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorProductOnObjectAndMorphismWithGivenTensorProducts( cat,
+        
+########
+function ( cat_1, s_1, a_1, beta_1, r_1 )
+    local hoisted_2_1, deduped_3_1;
+    deduped_3_1 := Cardinality( Source( beta_1 ) );
+    hoisted_2_1 := ListPerm( UnderlyingPermutation( beta_1 ), deduped_3_1 );
+    return CreateCapCategoryMorphismWithAttributes( cat_1, s_1, s_1, UnderlyingPermutation, PermList( Concatenation( List( [ 0 .. Cardinality( a_1 ) - 1 ], function ( i_2 )
+                  local hoisted_1_2;
+                  hoisted_1_2 := i_2 * deduped_3_1;
+                  return List( hoisted_2_1, function ( p_3 )
+                          return p_3 + hoisted_1_2;
+                      end );
+              end ) ) ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorProductOnObjects( cat,
+        
+########
+function ( cat_1, arg2_1, arg3_1 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Cardinality, Cardinality( arg2_1 ) * Cardinality( arg3_1 ) );
+end
+########
+        
+    , 100 );
+    
+    ##
+    AddTensorUnit( cat,
+        
+########
+function ( cat_1 )
+    return CreateCapCategoryObjectWithAttributes( cat_1, Cardinality, 1 );
+end
+########
+        
+    , 100 );
+    
+    if IsBound( cat!.precompiled_functions_added ) then
+        
+        # COVERAGE_IGNORE_NEXT_LINE
+        Error( "precompiled functions have already been added before" );
+        
+    fi;
+    
+    cat!.precompiled_functions_added := true;
+    
+end );
+
+BindGlobal( "PermutationCategory_precompiled", function (  )
+  local category_constructor, cat;
+    
+    category_constructor :=
+        
+        
+        function (  )
+    return PermutationCategory(  : no_precompiled_code := true );
+end;
+        
+        
+    
+    cat := category_constructor(  : FinalizeCategory := false, no_precompiled_code := true );
+    
+    ADD_FUNCTIONS_FOR_PermutationCategory_precompiled( cat );
+    
+    Finalize( cat );
+    
+    return cat;
+    
+end );

--- a/SubcategoriesForCAP/init.g
+++ b/SubcategoriesForCAP/init.g
@@ -7,3 +7,4 @@
 ReadPackage( "SubcategoriesForCAP", "gap/Subcategory.gd" );
 ReadPackage( "SubcategoriesForCAP", "gap/FullSubcategory.gd" );
 ReadPackage( "SubcategoriesForCAP", "gap/FunctorsForFullSubcategories.gd" );
+ReadPackage( "SubcategoriesForCAP", "gap/PermutationCategory.gd" );

--- a/SubcategoriesForCAP/read.g
+++ b/SubcategoriesForCAP/read.g
@@ -7,3 +7,4 @@
 ReadPackage( "SubcategoriesForCAP", "gap/Subcategory.gi" );
 ReadPackage( "SubcategoriesForCAP", "gap/FullSubcategory.gi" );
 ReadPackage( "SubcategoriesForCAP", "gap/FunctorsForFullSubcategories.gi" );
+ReadPackage( "SubcategoriesForCAP", "gap/PermutationCategory.gi" );


### PR DESCRIPTION
Depends on PR #851 

In principle, there is a derivation for `TensorProductOnMorphisms` from `TensorProductOnMorphismAndObject` and `TensorProductOnObjectAndMorphism`, but the compiled derivation contained too many `CreateCapCategory*` and is not as efficient as this manual code.

But I also didn't bother yet to investigate this thoroughly, because I already had the code for `TensorProductOnMorphisms` before introducing  `TensorProductOnMorphismAndObject` and `TensorProductOnObjectAndMorphism`.